### PR TITLE
Fix order of arguments to publicTaintsAreAsExpected() in x86, x64, and ARM code.

### DIFF
--- a/src/arch/arm/leakage-helpers.i.dfy
+++ b/src/arch/arm/leakage-helpers.i.dfy
@@ -329,8 +329,8 @@ lemma lemma_ifElse(pred:obool, ift:code, iff:code, fixedTime:bool,
 
 predicate method publicRegisterTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall r :: r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?
-        ==> (r in tsExpected.regTaint && tsExpected.regTaint[r].Public?)
+    forall r :: r in tsExpected.regTaint && tsExpected.regTaint[r].Public?
+        ==> (r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?)
 }
 
 predicate method publicTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)

--- a/src/arch/arm/leakage.i.dfy
+++ b/src/arch/arm/leakage.i.dfy
@@ -839,7 +839,7 @@ method checkIfCodeisLeakageFree(code:code, ts:taintState, tsExpected:taintState)
     b := fixedTime;
 
     if (b) {
-        b := publicTaintsAreAsExpected(tsExpected, ts');
+        b := publicTaintsAreAsExpected(ts', tsExpected);
 
        if (b == false) {
             return;

--- a/src/arch/x64/leakage-helpers.i.dfy
+++ b/src/arch/x64/leakage-helpers.i.dfy
@@ -1,0 +1,2852 @@
+include "leakage.s.dfy"
+include "../../lib/util/operations.i.dfy"
+
+module x64_leakage_helpers {
+
+import opened x64_def_s
+import opened x64_leakage_s
+import opened operations_i
+
+function method domain<U, V>(m: map<U,V>): set<U>
+    ensures forall i :: i in domain(m) <==> i in m;
+{
+    set s | s in m
+}
+
+predicate taintStateModInvariant(ts:taintState, ts':taintState)
+{
+       (forall r :: r in ts.regTaint ==> r in ts'.regTaint)
+    && (forall s :: s in ts.stackTaint ==> s in ts'.stackTaint)
+    && (forall x :: x in ts.xmmTaint ==> x in ts'.xmmTaint)
+}
+
+predicate insPostconditions(ins:ins, ts:taintState, ts':taintState,
+        fixedTime:bool)
+{
+    fixedTime ==>
+           (taintStateModInvariant(ts, ts')
+        && forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2'))
+}
+
+predicate blockPostconditions(block:codes, ts:taintState, ts':taintState,
+        fixedTime:bool)
+{
+    fixedTime ==>
+           (taintStateModInvariant(ts, ts')
+        && forall state1, state2, state1', state2' ::
+            (evalBlock(block, state1, state1')
+            && evalBlock(block, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2'))
+}
+
+predicate codePostconditions(code:code, ts:taintState, ts':taintState,
+        fixedTime:bool)
+{
+    fixedTime ==>
+           (taintStateModInvariant(ts, ts')
+        && forall state1, state2, state1', state2' ::
+            (evalCode(code, state1, state1')
+            && evalCode(code, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2'))
+}
+
+predicate specTaintCheckIns(ins:ins, ts:taintState, ts':taintState,
+        fixedTime:bool)
+{
+    insPostconditions(ins, ts, ts', fixedTime)
+}
+
+predicate specTaintCheckBlock(block:codes, ts:taintState, ts':taintState,
+        fixedTime:bool)
+{
+    blockPostconditions(block, ts, ts', fixedTime)
+    && if block.CNil? then
+        fixedTime == true && ts' == ts
+    else
+        exists ts_int ::
+            specTaintCheckCode(block.hd, ts, ts_int, fixedTime)
+            && specTaintCheckBlock(block.tl, ts_int, ts', fixedTime)
+}
+
+predicate specTaintCheckCode(code:code, ts:taintState, ts':taintState,
+        fixedTime:bool)
+    decreases code, 0
+{
+       codePostconditions(code, ts, ts', fixedTime)
+    && (code.Block? ==> specTaintCheckBlock(code.block, ts, ts', fixedTime))
+}
+
+function specMergeTaint(t1:taint, t2:taint) : taint
+    ensures specMergeTaint(t1, t2).Public? ==> t1.Public? && t2.Public?;
+{
+    if t1.Secret? || t2.Secret? then
+        Secret
+    else
+        Public
+}
+
+predicate specCombineTaints<T>(t1:map<T,taint>, t2:map<T,taint>,
+        t:map<T,taint>)
+{
+    forall elem :: elem in t
+        ==> (((elem in t1 || elem in t2)
+                && (elem in t1 && elem in t2 ==>
+                        t[elem] == specMergeTaint(t1[elem], t2[elem]))
+                && (elem in t1 && elem !in t2 ==> t[elem].Secret?)
+                && (elem in t2 && elem !in t1 ==> t[elem].Secret?))
+            && (t[elem].Public? ==> ((elem in t1 ==> t1[elem].Public?)
+                && (elem in t2 ==> t2[elem].Public?))))
+}
+
+predicate specCombineTaintStates(ts1:taintState, ts2:taintState,
+        ts:taintState)
+{
+       specCombineTaints(ts1.regTaint, ts2.regTaint, ts.regTaint)
+    && specCombineTaints(ts1.stackTaint, ts2.stackTaint, ts.stackTaint)
+    && specCombineTaints(ts1.xmmTaint, ts2.xmmTaint, ts.xmmTaint)
+    && ts.flagsTaint == specMergeTaint(ts1.flagsTaint, ts2.flagsTaint)
+    && taintStateModInvariant(ts1, ts)
+    && taintStateModInvariant(ts2, ts)
+}
+
+predicate taintSubset<T>(t1:map<T, taint>, t2:map<T, taint>)
+{
+    forall elem :: elem in t2 && t2[elem].Public? ==> elem in t1 && t1[elem].Public?
+}
+
+predicate taintStateSubset(ts1:taintState, ts2:taintState)
+{
+       taintSubset(ts1.regTaint, ts2.regTaint)
+    && taintSubset(ts1.stackTaint, ts2.stackTaint)
+    && taintSubset(ts1.xmmTaint, ts2.xmmTaint)
+    && (ts2.flagsTaint.Public? ==> ts1.flagsTaint.Public?)
+}
+
+lemma lemma_CombiningTaintsProducesSuperset<T>(t1:map<T, taint>, t2:map<T, taint>, t':map<T, taint>)
+    requires specCombineTaints(t1, t2, t');
+    ensures  taintSubset(t1, t');
+    ensures  taintSubset(t2, t');
+{
+}
+
+lemma lemma_CombiningTaintStatesProducesSuperset(ts1:taintState, ts2:taintState, ts':taintState)
+    requires specCombineTaintStates(ts1, ts2, ts');
+    ensures  taintStateSubset(ts1, ts');
+    ensures  taintStateSubset(ts2, ts');
+{
+    lemma_CombiningTaintsProducesSuperset(ts1.regTaint, ts2.regTaint, ts'.regTaint);
+    lemma_CombiningTaintsProducesSuperset(ts1.stackTaint, ts2.stackTaint, ts'.stackTaint);
+    lemma_CombiningTaintsProducesSuperset(ts1.xmmTaint, ts2.xmmTaint, ts'.xmmTaint);
+}
+
+lemma lemma_TaintSupersetImpliesPublicValuesAreSameIsPreserved(ts:taintState, ts':taintState, s1:state, s2:state)
+    requires publicValuesAreSame(ts, s1, s2);
+    requires taintStateSubset(ts, ts');
+    ensures  publicValuesAreSame(ts', s1, s2);
+{
+}
+
+function specOperandTaint(op:operand, ts:taintState) : taint
+{
+    match op {
+        case OConst(_)            => Public
+        case OReg(reg)            =>
+            if reg.X86Xmm? && reg.xmm in ts.xmmTaint then
+                ts.xmmTaint[reg.xmm]
+            else if reg.X86Xmm? then
+                Secret
+            else if reg in ts.regTaint then
+                ts.regTaint[reg]
+            else
+                Secret
+        case OStack(slot)          =>
+            if slot in ts.stackTaint then
+                ts.stackTaint[slot]
+            else
+                Secret
+        case OHeap(addr, taint)    =>
+            taint
+    }
+}
+
+function specOperandTaint64(op:operand, ts:taintState) : taint
+{
+    match op {
+        case OConst(_)            => Public
+        case OReg(reg)            =>
+            if reg.X86Xmm? && reg.xmm in ts.xmmTaint then
+                ts.xmmTaint[reg.xmm]
+            else if reg.X86Xmm? then
+                Secret
+            else if reg in ts.regTaint then
+                ts.regTaint[reg]
+            else
+                Secret
+        case OStack(slot)          =>
+            if slot in ts.stackTaint && slot + 1 in ts.stackTaint then
+                specMergeTaint(ts.stackTaint[slot], ts.stackTaint[slot + 1])
+            else
+                Secret
+        case OHeap(addr, taint)    =>
+            taint
+    }
+}
+
+function specTaint(value:Value, ts:taintState) : taint
+{
+    if value.Operand? then
+        specOperandTaint(value.o, ts)
+    else
+        specMergeTaint(specOperandTaint(value.p.o1, ts), specOperandTaint(value.p.o2, ts))
+
+}
+
+predicate specOperandDoesNotUseSecrets(o:operand, ts:taintState)
+{
+    if o.OConst? || o.OReg? || o.OStack? then
+        true
+    else
+        assert o.OHeap?;
+
+        var addr := o.addr;
+        if addr.MConst? then
+            true
+        else if addr.MReg? then
+            var reg_operand := OReg(addr.reg);
+            var regTaint := specOperandTaint(reg_operand, ts);
+            regTaint.Public?
+        else
+            assert addr.MIndex?;
+
+            var base_operand := OReg(addr.base);
+            var base_taint := specOperandTaint(base_operand, ts);
+
+            var index_operand := OReg(addr.index);
+            var index_taint := specOperandTaint(index_operand, ts);
+
+            base_taint.Public? && index_taint.Public?
+}
+
+// Used by AddCarry.
+predicate assertionsWithFlags(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint(src, ts);
+     var dstTaint := specOperandTaint(dst, ts);
+     var flagTaint := ts.flagsTaint;
+
+     var srcDstTaint := specMergeTaint(srcTaint, dstTaint);
+     var mergedTaint := specMergeTaint(srcDstTaint, flagTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret)
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by AddCarry64.
+predicate assertionsWithFlags64(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint64(src, ts);
+     var dstTaint := specOperandTaint64(dst, ts);
+     var flagTaint := ts.flagsTaint;
+
+     var srcDstTaint := specMergeTaint(srcTaint, dstTaint);
+     var mergedTaint := specMergeTaint(srcDstTaint, flagTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint][dst.s + 1 := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret)
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+predicate assertionsGetCf(dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+     var dstTaint := specOperandTaint(dst, ts);
+     var flagTaint := ts.flagsTaint;
+     var mergedTaint := specMergeTaint(dstTaint, flagTaint);
+
+    match dst
+        case OStack(st) =>
+            ((fixedTime == ftDst)
+            && ts' == ts.(stackTaint := ts.stackTaint[dst.s := mergedTaint]))
+        case OHeap(h, t) =>
+            ((fixedTime == (ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts)
+        case OReg(r) =>
+            ((fixedTime == ftDst)
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint]))
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+predicate assertionsNot(dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+     var dstTaint := specOperandTaint(dst, ts);
+
+    match dst
+        case OStack(st) =>
+            ((fixedTime == ftDst)
+            && ts' == ts.(flagsTaint := Secret))
+        case OHeap(h, t) =>
+            ((fixedTime == ftDst)
+            && ts' == ts.(flagsTaint := Secret))
+        case OReg(r) =>
+            ((fixedTime == ftDst)
+            && ts' == ts.(flagsTaint := Secret))
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by Mov.
+predicate assertionsCopy(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint(src, ts);
+
+    match dst
+        case OHeap(h, t) =>
+            (fixedTime == ((ftSrc && ftDst)
+                    && !(srcTaint.Secret? && dst.taint.Public?))
+            && ts' == ts)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := srcTaint])
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(stackTaint := ts.stackTaint[dst.s := srcTaint])
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by Mov64.
+predicate assertionsCopy64(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint64(src, ts);
+
+    match dst
+        case OHeap(h, t) =>
+            (fixedTime == ((ftSrc && ftDst)
+                    && !(srcTaint.Secret? && dst.taint.Public?))
+            && ts' == ts)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := srcTaint])
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(stackTaint := ts.stackTaint[dst.s := srcTaint][dst.s + 1 := srcTaint])
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by Add, Sub, Xor, And, Rol, Ror, Shl, and Shr.
+predicate assertionsWithoutFlags(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint(src, ts);
+     var dstTaint := specOperandTaint(dst, ts);
+
+     var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret)
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by Add64, Sub64, IMul64, Xor64, And64, Rol64, Ror64, Shl64, and Shr64.
+predicate assertionsWithoutFlags64(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint64(src, ts);
+     var dstTaint := specOperandTaint64(dst, ts);
+
+     var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint][dst.s + 1 := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret)
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+predicate assertionsXor32(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint(src, ts);
+     var dstTaint := specOperandTaint(dst, ts);
+
+     var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (src.OReg? && src == dst && fixedTime == true && ts' == ts.(regTaint := ts.regTaint[dst.r := Public], 
+                    flagsTaint := Secret))
+            || ((fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret))
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+predicate assertionsXor64(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint64(src, ts);
+     var dstTaint := specOperandTaint64(dst, ts);
+
+     var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    match dst
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(flagsTaint := Secret,
+                    stackTaint := ts.stackTaint[dst.s := mergedTaint][dst.s + 1 := mergedTaint])
+        case OHeap(h, t) =>
+            (fixedTime == (ftSrc && ftDst && !(mergedTaint.Secret? && dst.taint.Public?)))
+            && ts' == ts.(flagsTaint := Secret)
+        case OReg(r) =>
+            (src.OReg? && src == dst && fixedTime == true && ts' == ts.(regTaint := ts.regTaint[dst.r := Public], 
+                    flagsTaint := Secret))
+            || ((fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(regTaint := ts.regTaint[dst.r := mergedTaint],
+                    flagsTaint := Secret))
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+predicate assertionsMul(src:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+    var srcTaint := specOperandTaint(src, ts);
+    var eaxTaint := specOperandTaint(OReg(X86Eax), ts);
+    var taint := specMergeTaint(srcTaint, eaxTaint);
+
+    var ts_int := ts.(regTaint := ts.regTaint[X86Eax := taint]);
+    var ts_int_int := ts_int.(regTaint := ts_int.regTaint[X86Edx := taint]);
+
+    fixedTime == specOperandDoesNotUseSecrets(src, ts)
+    && ts' == ts_int_int.(flagsTaint := Secret)
+}
+
+predicate assertionsMul64(src:operand, ts:taintState, fixedTime:bool, ts':taintState)
+{
+    var srcTaint := specOperandTaint64(src, ts);
+    var eaxTaint := specOperandTaint64(OReg(X86Eax), ts);
+    var taint := specMergeTaint(srcTaint, eaxTaint);
+
+    var ts_int := ts.(regTaint := ts.regTaint[X86Eax := taint]);
+    var ts_int_int := ts_int.(regTaint := ts_int.regTaint[X86Edx := taint]);
+
+    fixedTime == specOperandDoesNotUseSecrets(src, ts)
+    && ts' == ts_int_int.(flagsTaint := Secret)
+}
+
+// Used by MOVDQU
+predicate assertionsMoveXmm(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+    requires !src.OStack? && !dst.OStack?;
+    requires src.OReg? ==> src.r.X86Xmm?;
+    requires dst.OReg? ==> dst.r.X86Xmm?;
+    requires src.OReg? || dst.OReg?;
+{
+     var ftSrc := specOperandDoesNotUseSecrets(src, ts);
+     var ftDst := specOperandDoesNotUseSecrets(dst, ts);
+
+     var srcTaint := specOperandTaint(src, ts);
+
+    match dst
+        case OHeap(h, t) =>
+            (fixedTime == ((ftSrc && ftDst)
+                    && !(srcTaint.Secret? && dst.taint.Public?))
+            && ts' == ts.(flagsTaint := Secret))
+        case OReg(r) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint], flagsTaint := Secret)
+        case OStack(st) =>
+            (fixedTime == (ftSrc && ftDst))
+            && ts' == ts.(stackTaint := ts.stackTaint[dst.s := srcTaint], flagsTaint := Secret)
+        case OConst(_) =>
+            fixedTime == false && ts' == ts
+}
+
+// Used by AESNI_imc, VPSLLDQ, Pshufd, and AESNI_keygen_assist.
+predicate assertionsCopyXmmWithFlags(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+    requires src.OReg? && src.r.X86Xmm?;
+    requires dst.OReg? && dst.r.X86Xmm?;
+{
+    var srcTaint := specOperandTaint(src, ts);
+
+    fixedTime == true
+    && ts' == ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint],
+                  flagsTaint := Secret)
+}
+
+// Used by AESNI_enc, AESNI_enc_last, AESNI_dec, AESNI_dec_last.
+predicate assertionsXmmWithFlags(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+    requires src.OReg? && src.r.X86Xmm?;
+    requires dst.OReg? && dst.r.X86Xmm?;
+{
+    var srcTaint := specOperandTaint(src, ts);
+    var dstTaint := specOperandTaint(dst, ts);
+    var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    fixedTime == true
+    && ts' == ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+                  flagsTaint := Secret)
+}
+
+predicate assertionsPxorXmmWithFlags(src:operand, dst:operand, ts:taintState, fixedTime:bool, ts':taintState)
+    requires src.OReg? && src.r.X86Xmm?;
+    requires dst.OReg? && dst.r.X86Xmm?;
+{
+    var srcTaint := specOperandTaint(src, ts);
+    var dstTaint := specOperandTaint(dst, ts);
+    var mergedTaint := specMergeTaint(srcTaint, dstTaint);
+
+    fixedTime == true
+    && ((dst == src && ts' == ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := Public],
+                  flagsTaint := Secret))
+        || (ts' == ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+                  flagsTaint := Secret)))
+}
+
+
+lemma lemma_ValiditiesOfPublic32BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 32, op)
+            ==> ValidSourceOperand(s2, 32, op);
+{
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 32, op)
+       && op.OHeap?
+    {
+        var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+        var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+        assert resolved_addr1 == resolved_addr2;
+        assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+    }
+}
+
+lemma lemma_ValiditiesOfPublic64BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint64(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 64, op)
+            ==> ValidSourceOperand(s2, 64, op);
+{
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint64(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 64, op) {
+       if op.OHeap? {
+            var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+            var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+
+            assert resolved_addr1 == resolved_addr2;
+
+            assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+            assert s1.heap[resolved_addr1+1] == s2.heap[resolved_addr1+1];
+            assert s1.heap[resolved_addr1+2] == s2.heap[resolved_addr1+2];
+            assert s1.heap[resolved_addr1+3] == s2.heap[resolved_addr1+3];
+
+            assert s1.heap[resolved_addr1+4] == s2.heap[resolved_addr1+4];
+            assert s1.heap[resolved_addr1+5] == s2.heap[resolved_addr1+5];
+            assert s1.heap[resolved_addr1+6] == s2.heap[resolved_addr1+6];
+            assert s1.heap[resolved_addr1+7] == s2.heap[resolved_addr1+7];
+        }
+    }
+}
+
+lemma lemma_ValiditiesOfPublic128BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    requires !op.OStack?;
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 128, op)
+            ==> ValidSourceOperand(s2, 128, op);
+{
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 128, op)
+    {
+        if op.OHeap? {
+            var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+            var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+            assert resolved_addr1 == resolved_addr2;
+            assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+            assert s1.heap[resolved_addr1+1] == s2.heap[resolved_addr1+1];
+            assert s1.heap[resolved_addr1+2] == s2.heap[resolved_addr1+2];
+            assert s1.heap[resolved_addr1+3] == s2.heap[resolved_addr1+3];
+            assert s1.heap[resolved_addr1+4] == s2.heap[resolved_addr1+4];
+            assert s1.heap[resolved_addr1+5] == s2.heap[resolved_addr1+5];
+            assert s1.heap[resolved_addr1+6] == s2.heap[resolved_addr1+6];
+            assert s1.heap[resolved_addr1+7] == s2.heap[resolved_addr1+7];
+            assert s1.heap[resolved_addr1+8] == s2.heap[resolved_addr1+8];
+            assert s1.heap[resolved_addr1+9] == s2.heap[resolved_addr1+9];
+            assert s1.heap[resolved_addr1+10] == s2.heap[resolved_addr1+10];
+            assert s1.heap[resolved_addr1+11] == s2.heap[resolved_addr1+11];
+            assert s1.heap[resolved_addr1+12] == s2.heap[resolved_addr1+12];
+            assert s1.heap[resolved_addr1+13] == s2.heap[resolved_addr1+13];
+            assert s1.heap[resolved_addr1+14] == s2.heap[resolved_addr1+14];
+            assert s1.heap[resolved_addr1+15] == s2.heap[resolved_addr1+15];
+        }
+    }
+}
+
+lemma lemma_ValuesOfPublic32BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 32, op)
+            ==>    ValidSourceOperand(s2, 32, op)
+                && eval_op32(s1, op) == eval_op32(s2, op);
+{
+    lemma_ValiditiesOfPublic32BitOperandAreSame(ts, s1, s2, op);
+
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 32, op)
+       && op.OHeap? {
+        assert ValidSourceOperand(s2, 32, op);
+        var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+        var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+        assert resolved_addr1 == resolved_addr2;
+        assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+    }
+}
+
+lemma lemma_ValuesOfPublic64BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint64(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 64, op)
+            ==>    ValidSourceOperand(s2, 64, op)
+                && eval_op64(s1, op) == eval_op64(s2, op);
+{
+    lemma_ValiditiesOfPublic64BitOperandAreSame(ts, s1, s2, op);
+
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint64(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 64, op)
+       && op.OHeap? {
+        assert ValidSourceOperand(s2, 64, op);
+        var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+        var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+        assert resolved_addr1 == resolved_addr2;
+        assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+        assert s1.heap[resolved_addr1+1] == s2.heap[resolved_addr1+1];
+        assert s1.heap[resolved_addr1+2] == s2.heap[resolved_addr1+2];
+        assert s1.heap[resolved_addr1+3] == s2.heap[resolved_addr1+3];
+        assert s1.heap[resolved_addr1+4] == s2.heap[resolved_addr1+4];
+        assert s1.heap[resolved_addr1+5] == s2.heap[resolved_addr1+5];
+        assert s1.heap[resolved_addr1+6] == s2.heap[resolved_addr1+6];
+        assert s1.heap[resolved_addr1+7] == s2.heap[resolved_addr1+7];
+    }
+}
+
+lemma lemma_ValuesOfPublic128BitOperandAreSame(ts:taintState, s1:state, s2:state, op:operand)
+    requires !op.OStack?;
+    ensures    specOperandDoesNotUseSecrets(op, ts)
+            && specOperandTaint(op, ts).Public?
+            && publicValuesAreSame(ts, s1, s2)
+            && ValidSourceOperand(s1, 128, op)
+            && Valid128BitOperand(s1, op)
+            ==>    ValidSourceOperand(s2, 128, op)
+                && Eval128BitOperand(s1, op) == Eval128BitOperand(s2, op);
+{
+    lemma_ValiditiesOfPublic128BitOperandAreSame(ts, s1, s2, op);
+
+    if    specOperandDoesNotUseSecrets(op, ts)
+       && specOperandTaint(op, ts).Public?
+       && publicValuesAreSame(ts, s1, s2)
+       && ValidSourceOperand(s1, 128, op)
+       && op.OHeap? {
+        assert ValidSourceOperand(s2, 128, op);
+        var resolved_addr1 := EvalMemAddr(s1.regs, op.addr);
+        var resolved_addr2 := EvalMemAddr(s2.regs, op.addr);
+        assert resolved_addr1 == resolved_addr2;
+        assert s1.heap[resolved_addr1+0] == s2.heap[resolved_addr1+0];
+        assert s1.heap[resolved_addr1+1] == s2.heap[resolved_addr1+1];
+        assert s1.heap[resolved_addr1+2] == s2.heap[resolved_addr1+2];
+        assert s1.heap[resolved_addr1+3] == s2.heap[resolved_addr1+3];
+        assert s1.heap[resolved_addr1+4] == s2.heap[resolved_addr1+4];
+        assert s1.heap[resolved_addr1+5] == s2.heap[resolved_addr1+5];
+        assert s1.heap[resolved_addr1+6] == s2.heap[resolved_addr1+6];
+        assert s1.heap[resolved_addr1+7] == s2.heap[resolved_addr1+7];
+        assert s1.heap[resolved_addr1+8] == s2.heap[resolved_addr1+8];
+        assert s1.heap[resolved_addr1+9] == s2.heap[resolved_addr1+9];
+        assert s1.heap[resolved_addr1+10] == s2.heap[resolved_addr1+10];
+        assert s1.heap[resolved_addr1+11] == s2.heap[resolved_addr1+11];
+        assert s1.heap[resolved_addr1+12] == s2.heap[resolved_addr1+12];
+        assert s1.heap[resolved_addr1+13] == s2.heap[resolved_addr1+13];
+        assert s1.heap[resolved_addr1+14] == s2.heap[resolved_addr1+14];
+        assert s1.heap[resolved_addr1+15] == s2.heap[resolved_addr1+15];
+    }
+}
+
+lemma { :timeLimitMultiplier 3 } lemma_Mov32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mov32?;
+    requires assertionsCopy(ins.srcMov, ins.dstMov, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcMov;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+    }
+}
+
+lemma { :timeLimitMultiplier 3 } lemma_Mov64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mov64?;
+    requires assertionsCopy64(ins.srcMov64, ins.dstMov64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcMov64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+
+        assert constTimeInvariant(ts', state1', state2');
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_Add32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Add32?;
+    requires assertionsWithoutFlags(ins.srcAdd, ins.dstAdd, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAdd;
+        var dst:operand := ins.dstAdd;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_Add64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Add64?;
+    requires assertionsWithoutFlags64(ins.srcAdd64, ins.dstAdd64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAdd64;
+        var dst:operand := ins.dstAdd64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 2} lemma_Sub32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Sub32?;
+    requires assertionsWithoutFlags(ins.srcSub, ins.dstSub, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcSub;
+        var dst:operand := ins.dstSub;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 2} lemma_Sub64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Sub64?;
+    requires assertionsWithoutFlags64(ins.srcSub64, ins.dstSub64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcSub64;
+        var dst:operand := ins.dstSub64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_IMul64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.IMul64?;
+    requires assertionsWithoutFlags64(ins.srcIMul64, ins.dstIMul64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcIMul64;
+        var dst:operand := ins.dstIMul64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_Xor32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Xor32?;
+    requires assertionsXor32(ins.srcXor, ins.dstXor, ts, fixedTime, ts');
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcXor;
+        var dst:operand := ins.dstXor;
+        if (src.OReg? && dst.OReg? && src == dst) {
+            var s1 := state1;
+            var s2 := state2;
+
+            var obs := insObs(s1, ins);
+            var obs2 := insObs(s2, ins);
+
+            var v := xor32(eval_op32(s1, dst), eval_op32(s1, src));
+            var v2 := xor32(eval_op32(s2, dst), eval_op32(s2, src));
+
+            assert evalUpdateAndHavocFlags(state1, dst, v, state1', obs);
+            assert state1' == state1.(regs := state1.regs[dst.r := v], flags := state1'.flags, trace := state1.trace + obs);
+            assert state2' == state2.(regs := state2.regs[dst.r := v2], flags := state2'.flags, trace := state2.trace + obs2);
+
+            assert state1'.regs[dst.r] == BitwiseXor(s1.regs[src.r], s1.regs[src.r]);
+            assert state2'.regs[dst.r] == BitwiseXor(s2.regs[src.r], s2.regs[src.r]);
+
+            lemma_BitwiseXorWithItself(s1.regs[src.r]);
+            lemma_BitwiseXorWithItself(s2.regs[src.r]);
+
+            assert state1'.regs[dst.r] == 0;
+            assert state2'.regs[dst.r] == 0;
+            assert state1'.regs[dst.r] == state2'.regs[dst.r];
+
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+
+
+        } else {
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+        }
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_Xor64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Xor64?;
+    requires assertionsXor64(ins.srcXorq, ins.dstXorq, ts, fixedTime, ts');
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcXorq;
+        var dst:operand := ins.dstXorq;
+        if (src.OReg? && dst.OReg? && src == dst) {
+            var s1 := state1;
+            var s2 := state2;
+
+            var obs := insObs(s1, ins);
+            var obs2 := insObs(s2, ins);
+
+            var v := xor64(eval_op64(s1, dst), eval_op64(s1, src));
+            var v2 := xor64(eval_op64(s2, dst), eval_op64(s2, src));
+
+            assert evalUpdateAndHavocFlags64(state1, dst, v, state1', obs);
+            assert state1' == state1.(regs := state1.regs[dst.r := v], flags := state1'.flags, trace := state1.trace + obs);
+            assert state2' == state2.(regs := state2.regs[dst.r := v2], flags := state2'.flags, trace := state2.trace + obs2);
+
+            assert state1'.regs[dst.r] == BitwiseXor64(s1.regs[src.r], s1.regs[src.r]);
+            assert state2'.regs[dst.r] == BitwiseXor64(s2.regs[src.r], s2.regs[src.r]);
+
+            lemma_BitwiseXor64WithItself(s1.regs[src.r]);
+            lemma_BitwiseXor64WithItself(s2.regs[src.r]);
+
+            assert state1'.regs[dst.r] == 0;
+            assert state2'.regs[dst.r] == 0;
+            assert state1'.regs[dst.r] == state2'.regs[dst.r];
+
+            lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+            lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+
+
+        } else {
+            lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+            lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+        }
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_And32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.And32?;
+    requires assertionsWithoutFlags(ins.srcAnd, ins.dstAnd, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAnd;
+        var dst:operand := ins.dstAnd;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma {:timeLimitMultiplier 3} lemma_And64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.And64?;
+    requires assertionsWithoutFlags64(ins.srcAnd64, ins.dstAnd64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAnd64;
+        var dst:operand := ins.dstAnd64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Rol32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Rol32?;
+    requires assertionsWithoutFlags(ins.amountRolConst, ins.dstRolConst, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountRolConst;
+        var dst:operand := ins.dstRolConst;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Ror32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Ror32?;
+    requires assertionsWithoutFlags(ins.amountRorConst, ins.dstRorConst, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountRorConst;
+        var dst:operand := ins.dstRorConst;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Shl32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shl32?;
+    requires assertionsWithoutFlags(ins.amountShlConst, ins.dstShlConst, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountShlConst;
+        var dst:operand := ins.dstShlConst;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Shl64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shl64?;
+    requires assertionsWithoutFlags64(ins.amountShlConst64, ins.dstShlConst64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountShlConst64;
+        var dst:operand := ins.dstShlConst64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Shr32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shr32?;
+    requires assertionsWithoutFlags(ins.amountShrConst, ins.dstShrConst, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountShrConst;
+        var dst:operand := ins.dstShrConst;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Shr64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shr64?;
+    requires assertionsWithoutFlags64(ins.amountShrConst64, ins.dstShrConst64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.amountShrConst64;
+        var dst:operand := ins.dstShrConst64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_Mov32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mov32?;
+    requires assertionsCopy(ins.srcMov, ins.dstMov, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Mov64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mov64?;
+    requires assertionsCopy64(ins.srcMov64, ins.dstMov64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Add32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Add32?;
+    requires assertionsWithoutFlags(ins.srcAdd, ins.dstAdd, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Add64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Add64?;
+    requires assertionsWithoutFlags64(ins.srcAdd64, ins.dstAdd64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Sub32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Sub32?;
+    requires assertionsWithoutFlags(ins.srcSub, ins.dstSub, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Sub64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Sub64?;
+    requires assertionsWithoutFlags64(ins.srcSub64, ins.dstSub64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_IMul64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.IMul64?;
+    requires assertionsWithoutFlags64(ins.srcIMul64, ins.dstIMul64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Xor32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Xor32?;
+    requires assertionsXor32(ins.srcXor, ins.dstXor, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Xor64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Xor64?;
+    requires assertionsXor64(ins.srcXorq, ins.dstXorq, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_And32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.And32?;
+    requires assertionsWithoutFlags(ins.srcAnd, ins.dstAnd, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_And64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.And64?;
+    requires assertionsWithoutFlags64(ins.srcAnd64, ins.dstAnd64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Rol32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Rol32?;
+    requires assertionsWithoutFlags(ins.amountRolConst, ins.dstRolConst, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Ror32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Ror32?;
+    requires assertionsWithoutFlags(ins.amountRorConst, ins.dstRorConst, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Shl32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shl32?;
+    requires assertionsWithoutFlags(ins.amountShlConst, ins.dstShlConst, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Shl64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shl64?;
+    requires assertionsWithoutFlags64(ins.amountShlConst64, ins.dstShlConst64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Shr32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shr32?;
+    requires assertionsWithoutFlags(ins.amountShrConst, ins.dstShrConst, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Shr64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Shr64?;
+    requires assertionsWithoutFlags64(ins.amountShrConst64, ins.dstShrConst64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Mul32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mul32?;
+    requires assertionsMul(ins.srcMul, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    var code := Ins(ins);
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2')
+    ensures state1'.trace == state2'.trace;
+    {
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, ins.srcMul);
+    }
+}
+
+lemma lemma_Mul64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mul64?;
+    requires assertionsMul64(ins.srcMul64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    var code := Ins(ins);
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2')
+    ensures state1'.trace == state2'.trace;
+    {
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, ins.srcMul64);
+    }
+}
+
+lemma lemma_Mul32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mul32?;
+    requires assertionsMul(ins.srcMul, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Mul64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Mul64?;
+    requires assertionsMul64(ins.srcMul64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma { :timeLimitMultiplier 3 } lemma_AddCarryHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AddCarry?;
+    requires assertionsWithFlags(ins.srcAddCarry, ins.dstAddCarry, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAddCarry;
+        var dst:operand := ins.dstAddCarry;
+
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma { :timeLimitMultiplier 3 } lemma_AddCarry64Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AddCarry64?;
+    requires assertionsWithFlags64(ins.srcAddCarry64, ins.dstAddCarry64, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcAddCarry64;
+        var dst:operand := ins.dstAddCarry64;
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, src);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, dst);
+    }
+}
+
+lemma lemma_AddCarryHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AddCarry?;
+    requires assertionsWithFlags(ins.srcAddCarry, ins.dstAddCarry, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AddCarry64Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AddCarry64?;
+    requires assertionsWithFlags64(ins.srcAddCarry64, ins.dstAddCarry64, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_Not32Helper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Not32?;
+    requires assertionsNot(ins.dstNot, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2')
+    ensures state1'.trace == state2'.trace;
+    {
+        if specOperandTaint(ins.dstNot, ts).Public? {
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, ins.dstNot);
+        }
+    }
+}
+
+lemma lemma_Not32Helper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Not32?;
+    requires assertionsNot(ins.dstNot, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_GetCfHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.GetCf?;
+    requires assertionsGetCf(ins.dstCf, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2')
+    ensures state1'.trace == state2'.trace;
+    {
+        if specOperandTaint(ins.dstCf, ts).Public? {
+            lemma_ValuesOfPublic32BitOperandAreSame(ts, state1, state2, ins.dstCf);
+        }
+    }
+}
+
+lemma lemma_GetCfHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.GetCf?;
+    requires assertionsGetCf(ins.dstCf, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_encHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_enc?;
+    requires ins.srcEnc.OReg? && ins.srcEnc.r.X86Xmm?;
+    requires ins.dstEnc.OReg? && ins.dstEnc.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcEnc, ins.dstEnc, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_encHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_enc?;
+    requires ins.srcEnc.OReg? && ins.srcEnc.r.X86Xmm?;
+    requires ins.dstEnc.OReg? && ins.dstEnc.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcEnc, ins.dstEnc, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_enc_lastHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_enc_last?;
+    requires ins.srcEncLast.OReg? && ins.srcEncLast.r.X86Xmm?;
+    requires ins.dstEncLast.OReg? && ins.dstEncLast.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcEncLast, ins.dstEncLast, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_enc_lastHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_enc_last?;
+    requires ins.srcEncLast.OReg? && ins.srcEncLast.r.X86Xmm?;
+    requires ins.dstEncLast.OReg? && ins.dstEncLast.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcEncLast, ins.dstEncLast, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_decHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_dec?;
+    requires ins.srcDec.OReg? && ins.srcDec.r.X86Xmm?;
+    requires ins.dstDec.OReg? && ins.dstDec.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcDec, ins.dstDec, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_decHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_dec?;
+    requires ins.srcDec.OReg? && ins.srcDec.r.X86Xmm?;
+    requires ins.dstDec.OReg? && ins.dstDec.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcDec, ins.dstDec, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_dec_lastHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_dec_last?;
+    requires ins.srcDecLast.OReg? && ins.srcDecLast.r.X86Xmm?;
+    requires ins.dstDecLast.OReg? && ins.dstDecLast.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcDecLast, ins.dstDecLast, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_dec_lastHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_dec_last?;
+    requires ins.srcDecLast.OReg? && ins.srcDecLast.r.X86Xmm?;
+    requires ins.dstDecLast.OReg? && ins.dstDecLast.r.X86Xmm?;
+    requires assertionsXmmWithFlags(ins.srcDecLast, ins.dstDecLast, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_imcHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_imc?;
+    requires ins.srcImc.OReg? && ins.srcImc.r.X86Xmm?;
+    requires ins.dstImc.OReg? && ins.dstImc.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcImc, ins.dstImc, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_imcHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_imc?;
+    requires ins.srcImc.OReg? && ins.srcImc.r.X86Xmm?;
+    requires ins.dstImc.OReg? && ins.dstImc.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcImc, ins.dstImc, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma { :timeLimitMultiplier 3 } lemma_MOVDQUHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.MOVDQU?;
+    requires !ins.srcMovdqu.OStack?;
+    requires !ins.dstMovdqu.OStack?;
+    requires ins.srcMovdqu.OReg? || ins.dstMovdqu.OReg?;
+    requires ins.srcMovdqu.OReg? ==> ins.srcMovdqu.r.X86Xmm?;
+    requires ins.dstMovdqu.OReg? ==> ins.dstMovdqu.r.X86Xmm?;
+    requires assertionsMoveXmm(ins.srcMovdqu, ins.dstMovdqu, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcMovdqu;
+        lemma_ValuesOfPublic128BitOperandAreSame(ts, state1, state2, src);
+    }
+}
+
+lemma lemma_MOVDQUHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.MOVDQU?;
+    requires !ins.srcMovdqu.OStack?;
+    requires !ins.dstMovdqu.OStack?;
+    requires ins.srcMovdqu.OReg? || ins.dstMovdqu.OReg?;
+    requires ins.srcMovdqu.OReg? ==> ins.srcMovdqu.r.X86Xmm?;
+    requires ins.dstMovdqu.OReg? ==> ins.dstMovdqu.r.X86Xmm?;
+    requires assertionsMoveXmm(ins.srcMovdqu, ins.dstMovdqu, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_VPSLLDQHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.VPSLLDQ?;
+    requires ins.srcVPSLLDQ.OReg? && ins.srcVPSLLDQ.r.X86Xmm?;
+    requires ins.dstVPSLLDQ.OReg? && ins.dstVPSLLDQ.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcVPSLLDQ, ins.dstVPSLLDQ, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_VPSLLDQHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.VPSLLDQ?;
+    requires ins.srcVPSLLDQ.OReg? && ins.srcVPSLLDQ.r.X86Xmm?;
+    requires ins.dstVPSLLDQ.OReg? && ins.dstVPSLLDQ.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcVPSLLDQ, ins.dstVPSLLDQ, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_PshufdHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Pshufd?;
+    requires ins.srcPshufd.OReg? && ins.srcPshufd.r.X86Xmm?;
+    requires ins.dstPshufd.OReg? && ins.dstPshufd.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcPshufd, ins.dstPshufd, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_PshufdHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Pshufd?;
+    requires ins.srcPshufd.OReg? && ins.srcPshufd.r.X86Xmm?;
+    requires ins.dstPshufd.OReg? && ins.dstPshufd.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcPshufd, ins.dstPshufd, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_PxorHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Pxor?;
+    requires ins.srcPXor.OReg? && ins.srcPXor.r.X86Xmm?;
+    requires ins.dstPXor.OReg? && ins.dstPXor.r.X86Xmm?;
+    requires assertionsPxorXmmWithFlags(ins.srcPXor, ins.dstPXor, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var src:operand := ins.srcPXor;
+        var dst:operand := ins.dstPXor;
+        if (src == dst) {
+            var s1 := state1;
+            var s2 := state2;
+            var s1' := state1';
+            var s2' := state2';
+
+            var obs := insObs(s1, ins);
+            var obs2 := insObs(s2, ins);
+
+            var v := QuadwordXor(s1.xmms[dst.r.xmm], s1.xmms[src.r.xmm]);
+            var v2 := QuadwordXor(s2.xmms[dst.r.xmm], s2.xmms[src.r.xmm]);
+
+            assert evalUpdateXmmsAndHavocFlags(state1, dst, v, state1', obs);
+            assert state1' == state1.(xmms := s1.xmms[dst.r.xmm := v], flags := state1'.flags, trace := state1.trace + obs);
+            assert state2' == state2.(xmms := s2.xmms[dst.r.xmm := v2], flags := state2'.flags, trace := state2.trace + obs2);
+
+            assert state1'.xmms[dst.r.xmm] == QuadwordXor(s1.xmms[src.r.xmm], s1.xmms[src.r.xmm]);
+            assert state2'.xmms[dst.r.xmm] == QuadwordXor(s2.xmms[src.r.xmm], s2.xmms[src.r.xmm]);
+
+            lemma_QuadwordXorWithItself(s1.xmms[src.r.xmm]);
+            lemma_QuadwordXorWithItself(s2.xmms[src.r.xmm]);
+
+            assert state1'.xmms[dst.r.xmm] == Quadword(0, 0, 0, 0);
+            assert state2'.xmms[dst.r.xmm] == Quadword(0, 0, 0, 0);
+            assert state1'.xmms[dst.r.xmm] == state2'.xmms[dst.r.xmm];
+        }
+    }
+}
+
+lemma lemma_PxorHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.Pxor?;
+    requires ins.srcPXor.OReg? && ins.srcPXor.r.X86Xmm?;
+    requires ins.dstPXor.OReg? && ins.dstPXor.r.X86Xmm?;
+    requires assertionsPxorXmmWithFlags(ins.srcPXor, ins.dstPXor, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+lemma lemma_AESNI_keygen_assistHelper1(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_keygen_assist?;
+    requires ins.srcKeygenAssist.OReg? && ins.srcKeygenAssist.r.X86Xmm?;
+    requires ins.dstKeygenAssist.OReg? && ins.dstKeygenAssist.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcKeygenAssist, ins.dstKeygenAssist, ts, fixedTime, ts');
+
+    ensures  fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> (constTimeInvariant(ts', state1', state2')
+                    && state1'.trace == state2'.trace);
+{
+    if fixedTime == false {
+        return;
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+    }
+}
+
+lemma lemma_AESNI_keygen_assistHelper2(ins:ins, fixedTime:bool, ts:taintState, ts':taintState)
+    requires ins.AESNI_keygen_assist?;
+    requires ins.srcKeygenAssist.OReg? && ins.srcKeygenAssist.r.X86Xmm?;
+    requires ins.dstKeygenAssist.OReg? && ins.dstKeygenAssist.r.X86Xmm?;
+    requires assertionsCopyXmmWithFlags(ins.srcKeygenAssist, ins.dstKeygenAssist, ts, fixedTime, ts');
+    requires fixedTime ==>
+        forall state1, state2, state1', state2' ::
+            (evalIns(ins, state1, state1')
+            && evalIns(ins, state2, state2')
+            && state1.ok && state1'.ok
+            && state2.ok && state2'.ok
+            && constTimeInvariant(ts, state1, state2))
+                ==> constTimeInvariant(ts', state1', state2');
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime)
+{
+}
+
+predicate method ValidRegsInXmmIns(ins:ins)
+{
+    match ins {
+        case Rand(x)                    =>  true
+        case Mov32(dst,src)             =>  true
+        case Mov64(dst,src)             =>  true
+        case Add32(dst, src)            =>  true
+        case Add64(dst, src)            =>  true
+        case AddLea64(dst, src1, src2)  =>  true
+        case Sub32(dst, src)            =>  true
+        case Sub64(dst, src)            =>  true
+        case Mul32(src)                 =>  true
+        case Mul64(src)                 =>  true
+        case IMul64(dst, src)           =>  true
+        case AddCarry(dst, src)         =>  true
+        case AddCarry64(dst, src)       =>  true
+        case BSwap32(dst)               =>  true
+        case Xor32(dst, src)            =>  true
+        case Xor64(dst, src)            =>  true
+        case And32(dst, src)            =>  true
+        case And64(dst, src)            =>  true
+        case Not32(dst)                 =>  true
+        case GetCf(dst)                 =>  true
+        case Rol32(dst, amount)         =>  true
+        case Ror32(dst, amount)         =>  true
+        case Shl32(dst, amount)         =>  true
+        case Shl64(dst, amount)         =>  true
+        case Shr32(dst, amount)         =>  true
+        case Shr64(dst, amount)         =>  true
+        case AESNI_enc(dst, src)                => IsXmmOperand(dst) && IsXmmOperand(src)
+        case AESNI_enc_last(dst, src)           => IsXmmOperand(dst) && IsXmmOperand(src)
+        case AESNI_dec(dst, src)                => IsXmmOperand(dst) && IsXmmOperand(src)
+        case AESNI_dec_last(dst, src)           => IsXmmOperand(dst) && IsXmmOperand(src)
+        case AESNI_imc(dst, src)                => IsXmmOperand(dst) && IsXmmOperand(src)
+        case AESNI_keygen_assist(dst, src, imm) => IsXmmOperand(dst) && IsXmmOperand(src) && imm.OConst?
+        case Pxor(dst, src)                     => IsXmmOperand(dst) && IsXmmOperand(src)
+        case Pshufd(dst, src, perm)             => IsXmmOperand(dst) && IsXmmOperand(src) && perm.OConst?
+        case VPSLLDQ(dst, src, count)           => IsXmmOperand(dst) && IsXmmOperand(src)
+        case MOVDQU(dst, src)                   => !src.OStack? && !dst.OStack? && (src.OReg? || dst.OReg?) && (src.OReg? ==> src.r.X86Xmm?) && (dst.OReg? ==> dst.r.X86Xmm?)
+    }
+}
+
+predicate AddrDoesNotUseXmmRegs(addr:maddr)
+{
+    if addr.MReg? then
+        !addr.reg.X86Xmm?
+    else if addr.MIndex? then
+        !addr.base.X86Xmm? && !addr.index.X86Xmm?
+    else
+        true
+}
+
+predicate OpAddrDoesNotUseXmmRegs(op:operand)
+{
+    op.OHeap? ==> AddrDoesNotUseXmmRegs(op.addr)
+}
+
+predicate AddrDoesNotUseXmmRegsInIns(ins:ins)
+{
+    match ins {
+        case Rand(x)                    => OpAddrDoesNotUseXmmRegs(x)
+        case Mov32(dst,src)             => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Mov64(dst,src)             => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Add32(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Add64(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AddLea64(dst, src1, src2)  => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src1) && OpAddrDoesNotUseXmmRegs(src2)
+        case Sub32(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Sub64(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Mul32(src)                 => OpAddrDoesNotUseXmmRegs(src)
+        case Mul64(src)                 => OpAddrDoesNotUseXmmRegs(src)
+        case IMul64(dst, src)           => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AddCarry(dst, src)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AddCarry64(dst, src)       => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case BSwap32(dst)               => OpAddrDoesNotUseXmmRegs(dst)
+        case Xor32(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Xor64(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case And32(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case And64(dst, src)            => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Not32(dst)                 => OpAddrDoesNotUseXmmRegs(dst)
+        case GetCf(dst)                 => OpAddrDoesNotUseXmmRegs(dst)
+        case Rol32(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case Ror32(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case Shl32(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case Shl64(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case Shr32(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case Shr64(dst, amount)         => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(amount)
+        case AESNI_enc(dst, src)                => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AESNI_enc_last(dst, src)           => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AESNI_dec(dst, src)                => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AESNI_dec_last(dst, src)           => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AESNI_imc(dst, src)                => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case AESNI_keygen_assist(dst, src, imm) => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src) && OpAddrDoesNotUseXmmRegs(imm)
+        case Pxor(dst, src)                     => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+        case Pshufd(dst, src, perm)             => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src) && OpAddrDoesNotUseXmmRegs(perm)
+        case VPSLLDQ(dst, src, count)           => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src) && OpAddrDoesNotUseXmmRegs(count)
+        case MOVDQU(dst, src)                   => OpAddrDoesNotUseXmmRegs(dst) && OpAddrDoesNotUseXmmRegs(src)
+    }
+}
+
+predicate ValidOperandsInBlock(block:codes)
+{
+    if block.CNil? then
+        true
+    else
+        ValidOperandsInCode(block.hd)
+        && ValidOperandsInBlock(block.tl)
+}
+
+predicate ValidOperandsInCode(code:code)
+{
+    match code {
+        case Ins(ins)               =>
+            ValidRegsInXmmIns(ins)
+            && AddrDoesNotUseXmmRegsInIns(ins)
+        case Block(block)           =>
+            ValidOperandsInBlock(block)
+        case IfElse(pred, ift, iff) =>
+            OpAddrDoesNotUseXmmRegs(pred.o1)
+            && OpAddrDoesNotUseXmmRegs(pred.o2)
+            && ValidOperandsInCode(ift)
+            && ValidOperandsInCode(iff)
+        case While(pred, block)     =>
+            OpAddrDoesNotUseXmmRegs(pred.o1)
+            && OpAddrDoesNotUseXmmRegs(pred.o2)
+            && ValidOperandsInCode(block)
+    }
+}
+
+lemma lemma_oBoolEvaluation(pred:obool, ift:code, iff:code, fixedTime:bool, ts:taintState)
+    requires specOperandTaint64(pred.o1, ts).Public?
+        && specOperandTaint64(pred.o2, ts).Public?
+        && specOperandDoesNotUseSecrets(pred.o1, ts)
+        && specOperandDoesNotUseSecrets(pred.o2, ts);
+
+    ensures fixedTime ==> (forall state1, state2, state1', state2' ::
+           evalIfElse(pred, ift, iff, state1, state1')
+        && evalIfElse(pred, ift, iff, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+            ==> evalOBool(state1, pred) == evalOBool(state2, pred));
+{
+    forall state1, state2, state1', state2' |
+           evalIfElse(pred, ift, iff, state1, state1')
+        && evalIfElse(pred, ift, iff, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+    ensures evalOBool(state1, pred) == evalOBool(state2, pred);
+    {
+        var state1_int :|
+            branchRelation(state1, state1_int, evalOBool(state1, pred))
+            && state1_int.ok
+            && (if evalOBool(state1, pred) then
+                    evalCode(ift, state1_int, state1')
+                else
+                    evalCode(iff, state1_int, state1'));
+
+        var state2_int :|
+            branchRelation(state2, state2_int, evalOBool(state2, pred))
+            && state2_int.ok
+            && (if evalOBool(state2, pred) then
+                    evalCode(ift, state2_int, state2')
+                else
+                    evalCode(iff, state2_int, state2'));
+
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, pred.o1);
+        lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, pred.o2);
+    }
+}
+
+lemma lemma_ifElse(pred:obool, ift:code, iff:code, fixedTime:bool,
+        ts:taintState, tsIft:taintState, tsIff:taintState, ts':taintState)
+    requires specOperandTaint64(pred.o1, ts).Public?
+        && specOperandTaint64(pred.o2, ts).Public?
+        && specOperandDoesNotUseSecrets(pred.o1, ts)
+        && specOperandDoesNotUseSecrets(pred.o2, ts);
+
+    requires specTaintCheckCode(ift, ts, tsIft, fixedTime);
+    requires specTaintCheckCode(iff, ts, tsIff, fixedTime);
+    requires specCombineTaintStates(tsIft, tsIff, ts');
+
+    requires forall state1, state2, state1', state2' ::
+        evalCode(ift, state1, state1')
+        && evalCode(ift, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+    ==> constTimeInvariant(tsIft, state1', state2');
+
+    requires forall state1, state2, state1', state2' ::
+        evalCode(iff, state1, state1')
+        && evalCode(iff, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+    ==> constTimeInvariant(tsIff, state1', state2');
+
+    ensures fixedTime ==> taintStateModInvariant(ts, ts');
+    ensures codePostconditions(IfElse(pred, ift, iff), ts, ts', fixedTime);
+    ensures fixedTime ==> isConstantTime(IfElse(pred, ift, iff), ts);
+    ensures specTaintCheckCode(IfElse(pred, ift, iff), ts, ts', fixedTime);
+    ensures fixedTime ==> isLeakageFree(IfElse(pred, ift, iff), ts, ts');
+{
+    if fixedTime == false {
+        return;
+    }
+
+    lemma_oBoolEvaluation(pred, ift, iff, fixedTime, ts);
+
+    forall state1, state2, state1', state2' |
+           evalIfElse(pred, ift, iff, state1, state1')
+        && evalIfElse(pred, ift, iff, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures state1'.trace == state2'.trace;
+    {
+        var state1_int :|
+            branchRelation(state1, state1_int, evalOBool(state1, pred)) && state1_int.ok
+            && (if evalOBool(state1, pred) then evalCode(ift, state1_int, state1') else evalCode(iff, state1_int, state1'));
+
+        var state2_int :|
+            branchRelation(state2, state2_int, evalOBool(state2, pred)) && state2_int.ok
+            && (if evalOBool(state2, pred) then evalCode(ift, state2_int, state2') else evalCode(iff, state2_int, state2'));
+
+        assert evalOBool(state1, pred) == evalOBool(state2, pred);
+        if evalOBool(state1, pred) {
+            assert evalCode(ift, state1_int, state1');
+            assert evalCode(ift, state2_int, state2');
+            assert state1_int.ok && state1'.ok;
+            assert state2_int.ok && state2'.ok;
+            assert constTimeInvariant(ts, state1_int, state2_int);
+            assert constTimeInvariant(tsIft, state1', state2');
+        } else {
+            assert evalCode(iff, state1_int, state1');
+            assert evalCode(iff, state2_int, state2');
+            assert state1_int.ok && state1'.ok;
+            assert state2_int.ok && state2'.ok;
+            assert constTimeInvariant(ts, state1_int, state2_int);
+            assert constTimeInvariant(tsIff, state1', state2');
+        }
+
+        assert evalOBool(state1, pred) ==> publicValuesAreSame(tsIft, state1', state2');
+        assert (evalOBool(state1, pred) == false) ==> publicValuesAreSame(tsIff, state1', state2');
+
+        forall
+        ensures publicFlagValuesAreSame(ts', state1', state2')
+        {
+        }
+
+        forall
+        ensures publicRegisterValuesAreSame(ts', state1', state2');
+        ensures publicStackValuesAreSame(ts', state1', state2');
+        ensures publicHeapValuesAreSame(state1', state2');
+        ensures publicXMMValuesAreSame(ts', state1', state2');
+        {
+        }
+
+        assert evalCode(IfElse(pred, ift, iff), state1, state1');
+        assert evalCode(IfElse(pred, ift, iff), state2, state2');
+
+        assert state1'.trace == state2'.trace;
+        assert constTimeInvariant(ts', state1', state2');
+    }
+
+    forall
+    ensures taintStateModInvariant(tsIft, ts');
+    ensures taintStateModInvariant(tsIff, ts');
+    ensures taintStateModInvariant(ts, ts');
+    {
+    }
+}
+
+predicate method publicXMMTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
+{
+    forall x :: x in tsAnalysis.xmmTaint && tsAnalysis.xmmTaint[x].Public?
+        ==> (x in tsExpected.xmmTaint && tsExpected.xmmTaint[x].Public?)
+}
+ 
+predicate method publicFlagTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
+
+{
+    tsAnalysis.flagsTaint == Public 
+        ==> tsExpected.flagsTaint == Public
+}
+ 
+predicate method publicStackTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
+{
+    forall s :: s in tsAnalysis.stackTaint && tsAnalysis.stackTaint[s].Public?
+        ==> (s in tsExpected.stackTaint && tsExpected.stackTaint[s].Public?)
+}
+ 
+predicate method publicRegisterTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
+{
+    forall r :: r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?
+        ==> (r in tsExpected.regTaint && tsExpected.regTaint[r].Public?)
+}
+
+predicate method publicTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
+{
+       publicXMMTaintsAreAsExpected(tsAnalysis, tsExpected)
+    && publicFlagTaintsAreAsExpected(tsAnalysis, tsExpected)
+    && publicStackTaintsAreAsExpected(tsAnalysis, tsExpected)
+    && publicRegisterTaintsAreAsExpected(tsAnalysis, tsExpected)
+}
+
+lemma lemma_ConsequencesOfIsLeakageFreeGivenStates(code:code, ts:taintState, ts':taintState)
+    requires (forall s1, s2, r1, r2 :: isExplicitLeakageFreeGivenStates(code, ts, ts', s1, s2, r1, r2));
+    ensures forall s1, s2, r1, r2 :: (evalCode(code, s1, r1)
+            && evalCode(code, s2, r2)
+            && s1.ok && r1.ok
+            && s2.ok && r2.ok
+            && constTimeInvariant(ts, s1, s2))
+            ==> publicValuesAreSame(ts', r1, r2); 
+{
+    forall s1, s2, r1, r2 
+        ensures (evalCode(code, s1, r1)
+            && evalCode(code, s2, r2)
+            && s1.ok && r1.ok
+            && s2.ok && r2.ok
+            && constTimeInvariant(ts, s1, s2))
+            ==> publicValuesAreSame(ts', r1, r2);
+    {
+        assert isExplicitLeakageFreeGivenStates(code, ts, ts', s1, s2, r1, r2);
+    }
+}
+}

--- a/src/arch/x64/leakage-helpers.i.dfy
+++ b/src/arch/x64/leakage-helpers.i.dfy
@@ -2880,27 +2880,27 @@ lemma lemma_ifElse(pred:obool, ift:code, iff:code, fixedTime:bool,
 
 predicate method publicXMMTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall x :: x in tsAnalysis.xmmTaint && tsAnalysis.xmmTaint[x].Public?
-        ==> (x in tsExpected.xmmTaint && tsExpected.xmmTaint[x].Public?)
+    forall x :: x in tsExpected.xmmTaint && tsExpected.xmmTaint[x].Public?
+        ==> (x in tsAnalysis.xmmTaint && tsAnalysis.xmmTaint[x].Public?)
 }
  
 predicate method publicFlagTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 
 {
-    tsAnalysis.flagsTaint == Public 
-        ==> tsExpected.flagsTaint == Public
+    tsExpected.flagsTaint == Public 
+        ==> tsAnalysis.flagsTaint == Public
 }
  
 predicate method publicStackTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall s :: s in tsAnalysis.stackTaint && tsAnalysis.stackTaint[s].Public?
-        ==> (s in tsExpected.stackTaint && tsExpected.stackTaint[s].Public?)
+    forall s :: s in tsExpected.stackTaint && tsExpected.stackTaint[s].Public?
+        ==> (s in tsAnalysis.stackTaint && tsAnalysis.stackTaint[s].Public?)
 }
  
 predicate method publicRegisterTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall r :: r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?
-        ==> (r in tsExpected.regTaint && tsExpected.regTaint[r].Public?)
+    forall r :: r in tsExpected.regTaint && tsExpected.regTaint[r].Public?
+        ==> (r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?)
 }
 
 predicate method publicTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)

--- a/src/arch/x64/leakage.i.dfy
+++ b/src/arch/x64/leakage.i.dfy
@@ -1849,7 +1849,7 @@ method {:timeLimitMultiplier 2} checkIfCodeisLeakageFree(code:code, ts:taintStat
     b := fixedTime;
 
     if (b) {
-        b := publicTaintsAreAsExpected(tsExpected, ts');
+        b := publicTaintsAreAsExpected(ts', tsExpected);
 
        if (b == false) {
             return;

--- a/src/arch/x64/leakage.i.dfy
+++ b/src/arch/x64/leakage.i.dfy
@@ -1,0 +1,1883 @@
+include "leakage-helpers.i.dfy"
+include "vale.i.dfy"
+include "leakage.s.dfy"
+
+module x64_const_time_i {
+
+import opened x64_leakage_helpers
+import opened x64_vale_i
+import opened x64_leakage_s
+
+method mergeTaint(t1:taint, t2:taint)
+    returns (taint:taint)
+
+    ensures taint == specMergeTaint(t1, t2)
+    ensures taint.Secret? == (t1.Secret? || t2.Secret?);
+{
+    if t1.Secret? || t2.Secret? {
+        taint := Secret;
+    } else {
+        taint := Public;
+    }
+}
+
+method operandTaint(op:operand, ts:taintState)
+    returns (operandTaint:taint)
+
+    ensures operandTaint == specOperandTaint(op, ts)
+    ensures operandTaint == Public ==>
+        ((op.OReg?   ==>
+            ((op.r.X86Xmm? && op.r.xmm in ts.xmmTaint)
+            || op.r in ts.regTaint))
+        && (op.OStack? ==> op.s in ts.stackTaint))
+{
+    match op {
+        case OConst(_)          => operandTaint := Public;
+        case OReg(reg)          =>
+            if reg.X86Xmm? {
+                if reg.xmm in ts.xmmTaint {
+                    operandTaint := ts.xmmTaint[reg.xmm];
+                } else {
+                    operandTaint := Secret;
+                }
+            } else if reg in ts.regTaint {
+                operandTaint := ts.regTaint[reg];
+            } else {
+                operandTaint := Secret;
+            }
+
+        case OStack(slot)       =>
+            if slot in ts.stackTaint {
+                operandTaint := ts.stackTaint[slot];
+            } else {
+                operandTaint := Secret;
+            }
+        case OHeap(addr, taint) => {
+            operandTaint := taint;
+        }
+    }
+}
+
+method operandTaint64(op:operand, ts:taintState)
+    returns (operandTaint:taint)
+
+    ensures operandTaint == specOperandTaint64(op, ts)
+    ensures operandTaint == Public ==>
+        ((op.OReg?   ==>
+            ((op.r.X86Xmm? && op.r.xmm in ts.xmmTaint)
+            || op.r in ts.regTaint))
+        && (op.OStack? ==> op.s in ts.stackTaint))
+{
+    match op {
+        case OConst(_)          => operandTaint := Public;
+        case OReg(reg)          =>
+            if reg.X86Xmm? {
+                if reg.xmm in ts.xmmTaint {
+                    operandTaint := ts.xmmTaint[reg.xmm];
+                } else {
+                    operandTaint := Secret;
+                }
+            } else if reg in ts.regTaint {
+                operandTaint := ts.regTaint[reg];
+            } else {
+                operandTaint := Secret;
+            }
+
+        case OStack(slot)       =>
+            if slot in ts.stackTaint && slot + 1 in ts.stackTaint {
+                var taint1 := ts.stackTaint[slot];
+                var taint2 := ts.stackTaint[slot + 1];
+                operandTaint := mergeTaint(taint1, taint2);
+            } else {
+                operandTaint := Secret;
+            }
+        case OHeap(addr, taint) => {
+            operandTaint := taint;
+        }
+    }
+}
+
+method maddrDoesNotUseSecrets(addr:maddr, ts:taintState)
+    returns (pass:bool)
+
+    ensures pass == specOperandDoesNotUseSecrets(OHeap(addr, Public), ts);
+{
+    if addr.MConst? {
+        pass := true;
+    } else if addr.MReg? {
+//        assert addr.reg.X86Xmm? == false;
+        var taint := operandTaint(OReg(addr.reg), ts);
+        pass := taint.Public?;
+    } else {
+        assert addr.MIndex?;
+        var baseOperand := OReg(addr.base);
+        var indexOperand := OReg(addr.index);
+
+        var baseTaint := operandTaint(baseOperand, ts);
+        var indexTaint := operandTaint(indexOperand, ts);
+
+        pass := baseTaint.Public? && indexTaint.Public?;
+    }
+}
+
+method operandDoesNotUseSecrets(o:operand, ts:taintState)
+    returns (pass:bool)
+
+    ensures  pass == specOperandDoesNotUseSecrets(o, ts);
+{
+    if o.OConst? || o.OReg? || o.OStack? {
+        pass := true;
+    } else {
+        assert o.OHeap?;
+        pass := maddrDoesNotUseSecrets(o.addr, ts);
+    }
+}
+
+method setTaint(value:Value, ts:taintState, valueTaint:taint)
+    returns (ts':taintState)
+
+    requires value.Operand?;
+
+    requires value.o.OConst? == false;
+    requires value.o.OHeap? == false;
+    ensures value.o.OReg?
+        ==> ts' == ts.(regTaint := ts.regTaint[value.o.r := valueTaint]);
+    ensures value.o.OStack?
+        ==> ts' == ts.(stackTaint := ts.stackTaint[value.o.s := valueTaint]);
+    ensures value.o.OHeap?  ==> ts == ts';
+{
+    match value.o {
+        case OReg(reg)      =>
+            ts' := ts.(regTaint := ts.regTaint[reg := valueTaint]);
+
+        case OStack(slot)   =>
+            ts' := ts.(stackTaint := ts.stackTaint[slot := valueTaint]);
+
+        case OHeap(_, _)    =>
+            ts' := ts;
+    }
+}
+
+method setTaint64(value:Value, ts:taintState, valueTaint:taint)
+    returns (ts':taintState)
+
+    requires value.Operand?;
+
+    requires value.o.OConst? == false;
+    requires value.o.OHeap? == false;
+    ensures value.o.OReg?
+        ==> ts' == ts.(regTaint := ts.regTaint[value.o.r := valueTaint]);
+    ensures value.o.OStack?
+        ==> ts' == ts.(stackTaint := ts.stackTaint[value.o.s := valueTaint][value.o.s + 1 := valueTaint]);
+    ensures value.o.OHeap?  ==> ts == ts';
+{
+    match value.o {
+        case OReg(reg)      =>
+            ts' := ts.(regTaint := ts.regTaint[reg := valueTaint]);
+
+        case OStack(slot)   =>
+            ts' := ts.(stackTaint := ts.stackTaint[slot := valueTaint][slot + 1 := valueTaint]);
+
+        case OHeap(_, _)    =>
+            ts' := ts;
+    }
+}
+
+method checkIfMov32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Mov32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcMov;
+    var dst := ins.dstMov;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        fixedTime := fixedTime && !(srcTaint.Secret? && dst.taint.Public?);
+        ts' := ts;
+    } else {
+        ts' := setTaint(Operand(dst), ts, srcTaint);
+    }
+
+    if fixedTime == false {
+        return;
+    }
+
+    lemma_Mov32Helper1(ins, fixedTime, ts, ts');
+    lemma_Mov32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfMov64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Mov64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcMov64;
+    var dst := ins.dstMov64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        fixedTime := fixedTime && !(srcTaint.Secret? && dst.taint.Public?);
+        ts' := ts;
+    } else {
+        ts' := setTaint64(Operand(dst), ts, srcTaint);
+    }
+
+    if fixedTime == false {
+        return;
+    }
+
+    lemma_Mov64Helper1(ins, fixedTime, ts, ts');
+    lemma_Mov64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfNot32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Not32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var dst := ins.dstNot;
+    fixedTime := operandDoesNotUseSecrets(dst, ts);
+    var taint := operandTaint(dst, ts);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else {
+        ts' := ts.(flagsTaint := Secret);
+    }
+
+    lemma_Not32Helper1(ins, fixedTime, ts, ts');
+    lemma_Not32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfRandConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Rand?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var dst := ins.xRand;
+    fixedTime := operandDoesNotUseSecrets(ins.xRand, ts);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && (dst.taint.Secret?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, Secret);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures fixedTime ==> constTimeInvariant(ts', state1', state2')
+    {
+    }
+
+    forall
+    ensures fixedTime ==> isConstantTime(Ins(ins), ts);
+    {
+    }
+
+    forall
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime);
+    {
+    }
+}
+
+method checkIfAdd32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Add32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAdd;
+    var dst := ins.dstAdd;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Add32Helper1(ins, fixedTime, ts, ts');
+    lemma_Add32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAdd64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Add64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAdd64;
+    var dst := ins.dstAdd64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Add64Helper1(ins, fixedTime, ts, ts');
+    lemma_Add64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAddLea64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AddLea64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src1 := ins.src1AddLea64;
+    var src2 := ins.src2AddLea64;
+    var dst := ins.dstAddLea64;
+
+    var ftSrc1 := operandDoesNotUseSecrets(src1, ts);
+    var ftSrc2 := operandDoesNotUseSecrets(src2, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+
+    fixedTime := ftSrc1 && ftSrc2 && ftDst;
+
+    var src1Taint := operandTaint64(src1, ts);
+    var src2Taint := operandTaint64(src2, ts);
+    var dstTaint := operandTaint64(dst, ts);
+
+    var srcTaint := mergeTaint(src1Taint, src2Taint);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_AddLea64Helper1(ins, fixedTime, ts, ts');
+    lemma_AddLea64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfSub32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Sub32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcSub;
+    var dst := ins.dstSub;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Sub32Helper1(ins, fixedTime, ts, ts');
+    lemma_Sub32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfSub64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Sub64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcSub64;
+    var dst := ins.dstSub64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Sub64Helper1(ins, fixedTime, ts, ts');
+    lemma_Sub64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfMul32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Mul32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcMul;
+    fixedTime := operandDoesNotUseSecrets(src, ts);
+
+    var eaxTaint := operandTaint(OReg(X86Eax), ts);
+    var srcTaint := operandTaint(src, ts);
+    var taint := mergeTaint(srcTaint, eaxTaint);
+
+    ts' := setTaint(Operand(OReg(X86Eax)), ts, taint);
+    ts' := setTaint(Operand(OReg(X86Edx)), ts', taint);
+    ts' := ts'.(flagsTaint := Secret);
+
+    lemma_Mul32Helper1(ins, fixedTime, ts, ts');
+    lemma_Mul32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfMul64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Mul64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcMul64;
+    fixedTime := operandDoesNotUseSecrets(src, ts);
+
+    var eaxTaint := operandTaint64(OReg(X86Eax), ts);
+    var srcTaint := operandTaint64(src, ts);
+    var taint := mergeTaint(srcTaint, eaxTaint);
+
+    ts' := setTaint64(Operand(OReg(X86Eax)), ts, taint);
+    ts' := setTaint64(Operand(OReg(X86Edx)), ts', taint);
+    ts' := ts'.(flagsTaint := Secret);
+
+    lemma_Mul64Helper1(ins, fixedTime, ts, ts');
+    lemma_Mul64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfIMul64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.IMul64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcIMul64;
+    var dst := ins.dstIMul64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_IMul64Helper1(ins, fixedTime, ts, ts');
+    lemma_IMul64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAddCarryConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AddCarry?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAddCarry;
+    var dst := ins.dstAddCarry;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    var flagTaint := ts.flagsTaint;
+    taint := mergeTaint(taint, flagTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_AddCarryHelper1(ins, fixedTime, ts, ts');
+    lemma_AddCarryHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAddCarry64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AddCarry64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAddCarry64;
+    var dst := ins.dstAddCarry64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    var flagTaint := ts.flagsTaint;
+    taint := mergeTaint(taint, flagTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_AddCarry64Helper1(ins, fixedTime, ts, ts');
+    lemma_AddCarry64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfXor32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Xor32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcXor;
+    var dst := ins.dstXor;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else if dst.OReg? && src.OReg? && src == dst {
+        ts' := setTaint(Operand(dst), ts, Public);
+        ts' := ts'.(flagsTaint := Secret);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Xor32Helper1(ins, fixedTime, ts, ts');
+    lemma_Xor32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfXor64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Xor64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcXorq;
+    var dst := ins.dstXorq;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else if dst.OReg? && src.OReg? && src == dst {
+        ts' := setTaint64(Operand(dst), ts, Public);
+        ts' := ts'.(flagsTaint := Secret);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Xor64Helper1(ins, fixedTime, ts, ts');
+    lemma_Xor64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAnd32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.And32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAnd;
+    var dst := ins.dstAnd;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_And32Helper1(ins, fixedTime, ts, ts');
+    lemma_And32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAnd64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.And64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcAnd64;
+    var dst := ins.dstAnd64;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint64(src, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(srcTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_And64Helper1(ins, fixedTime, ts, ts');
+    lemma_And64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfGetCfConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.GetCf?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var dst := ins.dstCf;
+
+    fixedTime := operandDoesNotUseSecrets(dst, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var flagsTaint := ts.flagsTaint;
+    var taint := mergeTaint(flagsTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+        ts' := ts;
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+    }
+
+    lemma_GetCfHelper1(ins, fixedTime, ts, ts');
+    lemma_GetCfHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfRol32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Rol32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountRolConst;
+    var dst := ins.dstRolConst;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint(amt, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Rol32Helper1(ins, fixedTime, ts, ts');
+    lemma_Rol32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfRor32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Ror32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountRorConst;
+    var dst := ins.dstRorConst;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint(amt, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Ror32Helper1(ins, fixedTime, ts, ts');
+    lemma_Ror32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfBSwap32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.BSwap32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    fixedTime := true;
+    ts' := ts;
+
+    forall state1, state2, state1', state2' |
+        (evalIns(ins, state1, state1')
+        && evalIns(ins, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures fixedTime ==> constTimeInvariant(ts', state1', state2')
+    {
+    }
+
+    forall
+    ensures fixedTime ==> isConstantTime(Ins(ins), ts);
+    {
+    }
+
+    forall
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime);
+    {
+    }
+}
+
+method checkIfShl32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Shl32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountShlConst;
+    var dst := ins.dstShlConst;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint(amt, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Shl32Helper1(ins, fixedTime, ts, ts');
+    lemma_Shl32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfShl64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Shl64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountShlConst64;
+    var dst := ins.dstShlConst64;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint64(amt, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Shl64Helper1(ins, fixedTime, ts, ts');
+    lemma_Shl64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfShr32ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Shr32?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountShrConst;
+    var dst := ins.dstShrConst;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint(amt, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Shr32Helper1(ins, fixedTime, ts, ts');
+    lemma_Shr32Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfShr64ConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Shr64?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var amt := ins.amountShrConst64;
+    var dst := ins.dstShrConst64;
+
+    var ftAmt := operandDoesNotUseSecrets(amt, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftAmt && ftDst;
+
+    var amtTaint := operandTaint64(amt, ts);
+    var dstTaint := operandTaint64(dst, ts);
+    var taint := mergeTaint(amtTaint, dstTaint);
+
+    if dst.OConst? {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        ts' := ts.(flagsTaint := Secret);
+        fixedTime := fixedTime && !(taint.Secret? && dst.taint.Public?);
+    } else {
+        ts' := setTaint64(Operand(dst), ts, taint);
+        ts' := ts'.(flagsTaint := Secret);
+    }
+
+    lemma_Shr64Helper1(ins, fixedTime, ts, ts');
+    lemma_Shr64Helper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_encConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_enc?;
+    requires ins.srcEnc.OReg? && ins.srcEnc.r.X86Xmm?;
+    requires ins.dstEnc.OReg? && ins.dstEnc.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcEnc;
+    var dst := ins.dstEnc;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var mergedTaint := mergeTaint(srcTaint, dstTaint);
+
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_encHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_encHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_enc_lastConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_enc_last?;
+    requires ins.srcEncLast.OReg? && ins.srcEncLast.r.X86Xmm?;
+    requires ins.dstEncLast.OReg? && ins.dstEncLast.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcEncLast;
+    var dst := ins.dstEncLast;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var mergedTaint := mergeTaint(srcTaint, dstTaint);
+
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_enc_lastHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_enc_lastHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_decConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_dec?;
+    requires ins.srcDec.OReg? && ins.srcDec.r.X86Xmm?;
+    requires ins.dstDec.OReg? && ins.dstDec.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcDec;
+    var dst := ins.dstDec;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var mergedTaint := mergeTaint(srcTaint, dstTaint);
+
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_decHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_decHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_dec_lastConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_dec_last?;
+    requires ins.srcDecLast.OReg? && ins.srcDecLast.r.X86Xmm?;
+    requires ins.dstDecLast.OReg? && ins.dstDecLast.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcDecLast;
+    var dst := ins.dstDecLast;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    var dstTaint := operandTaint(dst, ts);
+    var mergedTaint := mergeTaint(srcTaint, dstTaint);
+
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_dec_lastHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_dec_lastHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_imcConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_imc?;
+    requires ins.srcImc.OReg? && ins.srcImc.r.X86Xmm?;
+    requires ins.dstImc.OReg? && ins.dstImc.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcImc;
+    var dst := ins.dstImc;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_imcHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_imcHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfVPSLLDQConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.VPSLLDQ?;
+    requires ins.srcVPSLLDQ.OReg? && ins.srcVPSLLDQ.r.X86Xmm?;
+    requires ins.dstVPSLLDQ.OReg? && ins.dstVPSLLDQ.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcVPSLLDQ;
+    var dst := ins.dstVPSLLDQ;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint],
+               flagsTaint := Secret);
+
+    lemma_VPSLLDQHelper1(ins, fixedTime, ts, ts');
+    lemma_VPSLLDQHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfMOVDQUConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.MOVDQU?;
+    requires (ins.srcMovdqu.OReg? && ins.srcMovdqu.r.X86Xmm?) || (ins.dstMovdqu.OReg? && ins.dstMovdqu.r.X86Xmm?);
+    requires !ins.srcMovdqu.OStack? && !ins.dstMovdqu.OStack?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcMovdqu;
+    var dst := ins.dstMovdqu;
+
+    var ftSrc := operandDoesNotUseSecrets(src, ts);
+    var ftDst := operandDoesNotUseSecrets(dst, ts);
+    fixedTime := ftSrc && ftDst;
+
+    var srcTaint := operandTaint(src, ts);
+
+    if dst.OConst? || dst.OStack? || src.OStack? || (src.OReg? && !src.r.X86Xmm?) || (dst.OReg? && !dst.r.X86Xmm?) {
+        fixedTime := false;
+        ts' := ts;
+    } else if dst.OHeap? {
+        fixedTime := fixedTime && !(srcTaint.Secret? && dst.taint.Public?);
+        ts' := ts.(flagsTaint := Secret);
+    } else {
+        ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint], flagsTaint := Secret);
+    }
+
+    if fixedTime == false {
+        return;
+    }
+
+    lemma_MOVDQUHelper1(ins, fixedTime, ts, ts');
+    lemma_MOVDQUHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfPshufdConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Pshufd?;
+    requires ins.srcPshufd.OReg? && ins.srcPshufd.r.X86Xmm?;
+    requires ins.dstPshufd.OReg? && ins.dstPshufd.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcPshufd;
+    var dst := ins.dstPshufd;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint],
+               flagsTaint := Secret);
+
+    lemma_PshufdHelper1(ins, fixedTime, ts, ts');
+    lemma_PshufdHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfPxorConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.Pxor?;
+    requires ins.srcPXor.OReg? && ins.srcPXor.r.X86Xmm?;
+    requires ins.dstPXor.OReg? && ins.dstPXor.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcPXor;
+    var dst := ins.dstPXor;
+
+    fixedTime := true;
+
+    if src == dst {
+        ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := Public],
+                   flagsTaint := Secret);
+    } else {
+        var srcTaint := operandTaint(src, ts);
+        var dstTaint := operandTaint(dst, ts);
+        var mergedTaint := mergeTaint(srcTaint, dstTaint);
+
+        ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := mergedTaint],
+                   flagsTaint := Secret);
+    }
+    lemma_PxorHelper1(ins, fixedTime, ts, ts');
+    lemma_PxorHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfAESNI_keygen_assistConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    requires ins.AESNI_keygen_assist?;
+    requires ins.srcKeygenAssist.OReg? && ins.srcKeygenAssist.r.X86Xmm?;
+    requires ins.dstKeygenAssist.OReg? && ins.dstKeygenAssist.r.X86Xmm?;
+    ensures  specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures  fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures  fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    var src := ins.srcKeygenAssist;
+    var dst := ins.dstKeygenAssist;
+
+    fixedTime := true;
+
+    var srcTaint := operandTaint(src, ts);
+    ts' := ts.(xmmTaint := ts.xmmTaint[dst.r.xmm := srcTaint],
+               flagsTaint := Secret);
+
+    lemma_AESNI_keygen_assistHelper1(ins, fixedTime, ts, ts');
+    lemma_AESNI_keygen_assistHelper2(ins, fixedTime, ts, ts');
+}
+
+method checkIfInstructionConsumesFixedTime(ins:ins, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+    //requires AddrDoesNotUseXmmRegsInIns(ins);
+    requires ValidRegsInXmmIns(ins);
+
+    ensures specTaintCheckIns(ins, ts, ts', fixedTime);
+    ensures fixedTime ==> isConstantTime(Ins(ins), ts);
+    ensures fixedTime ==> isLeakageFree(Ins(ins), ts, ts');
+{
+    match ins {
+        case Rand(x)            => fixedTime, ts' := checkIfRandConsumesFixedTime(ins, ts);
+        case Mov32(dst,src)     => fixedTime, ts' := checkIfMov32ConsumesFixedTime(ins, ts);
+        case Mov64(dst,src)     => fixedTime, ts' := checkIfMov64ConsumesFixedTime(ins, ts);
+        case Add32(dst, src)    => fixedTime, ts' := checkIfAdd32ConsumesFixedTime(ins, ts);
+        case Add64(dst, src)    => fixedTime, ts' := checkIfAdd64ConsumesFixedTime(ins, ts);
+        case AddLea64(dst, src1, src2) => fixedTime, ts' := checkIfAddLea64ConsumesFixedTime(ins, ts);
+        case Sub32(dst, src)    => fixedTime, ts' := checkIfSub32ConsumesFixedTime(ins, ts);
+        case Sub64(dst, src)    => fixedTime, ts' := checkIfSub64ConsumesFixedTime(ins, ts);
+        case Mul32(src)         => fixedTime, ts' := checkIfMul32ConsumesFixedTime(ins, ts);
+        case Mul64(src)         => fixedTime, ts' := checkIfMul64ConsumesFixedTime(ins, ts);
+        case IMul64(dst, src)   => fixedTime, ts' := checkIfIMul64ConsumesFixedTime(ins, ts);
+        case AddCarry(dst, src) => fixedTime, ts' := checkIfAddCarryConsumesFixedTime(ins, ts);
+        case AddCarry64(dst, src) => fixedTime, ts' := checkIfAddCarry64ConsumesFixedTime(ins, ts);
+        case Xor32(dst, src)    => fixedTime, ts' := checkIfXor32ConsumesFixedTime(ins, ts);
+        case Xor64(dst, src)    => fixedTime, ts' := checkIfXor64ConsumesFixedTime(ins, ts);
+        case And32(dst, src)    => fixedTime, ts' := checkIfAnd32ConsumesFixedTime(ins, ts);
+        case And64(dst, src)    => fixedTime, ts' := checkIfAnd64ConsumesFixedTime(ins, ts);
+        case Not32(dst)         => fixedTime, ts' := checkIfNot32ConsumesFixedTime(ins, ts);
+        case GetCf(dst)         => fixedTime, ts' := checkIfGetCfConsumesFixedTime(ins, ts);
+        case Rol32(dst, amount) => fixedTime, ts' := checkIfRol32ConsumesFixedTime(ins, ts);
+        case Ror32(dst, amount) => fixedTime, ts' := checkIfRor32ConsumesFixedTime(ins, ts);
+        case Shl32(dst, amount) => fixedTime, ts' := checkIfShl32ConsumesFixedTime(ins, ts);
+        case Shl64(dst, amount) => fixedTime, ts' := checkIfShl64ConsumesFixedTime(ins, ts);
+        case Shr32(dst, amount) => fixedTime, ts' := checkIfShr32ConsumesFixedTime(ins, ts);
+        case Shr64(dst, amount) => fixedTime, ts' := checkIfShr64ConsumesFixedTime(ins, ts);
+        case BSwap32(dst)       => fixedTime, ts' := checkIfBSwap32ConsumesFixedTime(ins, ts);
+        case AESNI_enc(dst, src)                => fixedTime, ts' := checkIfAESNI_encConsumesFixedTime(ins, ts);
+        case AESNI_enc_last(dst, src)           => fixedTime, ts' := checkIfAESNI_enc_lastConsumesFixedTime(ins, ts);
+        case AESNI_dec(dst, src)                => fixedTime, ts' := checkIfAESNI_decConsumesFixedTime(ins, ts);
+        case AESNI_dec_last(dst, src)           => fixedTime, ts' := checkIfAESNI_dec_lastConsumesFixedTime(ins, ts);
+        case AESNI_imc(dst, src)                => fixedTime, ts' := checkIfAESNI_imcConsumesFixedTime(ins, ts);
+        case AESNI_keygen_assist(dst, src, imm) => fixedTime, ts' := checkIfAESNI_keygen_assistConsumesFixedTime(ins, ts);
+        case Pxor(dst, src)                     => fixedTime, ts' := checkIfPxorConsumesFixedTime(ins, ts);
+        case Pshufd(dst, src, perm)             => fixedTime, ts' := checkIfPshufdConsumesFixedTime(ins, ts);
+        case VPSLLDQ(dst, src, _)               => fixedTime, ts' := checkIfVPSLLDQConsumesFixedTime(ins, ts);
+        case MOVDQU(dst, src)                   => fixedTime, ts' := checkIfMOVDQUConsumesFixedTime(ins, ts);
+    }
+}
+
+method { :timeLimitMultiplier 4 } checkIfBlockConsumesFixedTime(block:codes, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    //requires ValidOperandsInBlock(block);
+    ensures fixedTime ==> taintStateModInvariant(ts, ts');
+    ensures fixedTime ==> specTaintCheckBlock(block, ts, ts', fixedTime);
+    decreases *
+{
+    if block.CNil? {
+        ts' := ts;
+        fixedTime := true;
+        return;
+    }
+
+    var ts_int;
+    fixedTime, ts_int := checkIfCodeConsumesFixedTime(block.hd, ts);
+    if (fixedTime == false) {
+        ts' := ts;
+        return;
+    }
+
+    assert specTaintCheckCode(block.hd, ts, ts_int, fixedTime);
+    assert codePostconditions(block.hd, ts, ts_int, fixedTime);
+
+    forall state1, state2, state1_int, state2_int |
+        (evalCode(block.hd, state1, state1_int)
+        && evalCode(block.hd, state2, state2_int)
+        && state1.ok && state1_int.ok
+        && state2.ok && state2_int.ok
+        && constTimeInvariant(ts, state1, state2))
+    ensures constTimeInvariant(ts_int, state1_int, state2_int)
+    ensures taintStateModInvariant(ts, ts_int);
+    {
+    }
+
+    fixedTime, ts' := checkIfBlockConsumesFixedTime(block.tl, ts_int);
+    if (fixedTime == false) {
+        return;
+    }
+
+    assert specTaintCheckBlock(block.tl, ts_int, ts', fixedTime);
+
+    forall state1_int, state2_int, state1', state2' |
+        evalBlock(block.tl, state1_int, state1')
+        && evalBlock(block.tl, state2_int, state2')
+        && state1_int.ok && state1'.ok
+        && state2_int.ok && state2'.ok
+        && constTimeInvariant(ts_int, state1_int, state2_int)
+    ensures constTimeInvariant(ts', state1', state2');
+    ensures taintStateModInvariant(ts_int, ts');
+    {
+    }
+
+    forall state1, state2, state1_int, state2_int, state1', state2' |
+            taintStateModInvariant(ts, ts_int)
+            && taintStateModInvariant(ts_int, ts')
+            && evalCode(block.hd, state1, state1_int)
+            && evalCode(block.hd, state2, state2_int)
+            && constTimeInvariant(ts, state1, state2)
+            && evalBlock(block.tl, state1_int, state1')
+            && evalBlock(block.tl, state2_int, state2')
+            && constTimeInvariant(ts_int, state1_int, state2_int)
+            && state1.ok && state1_int.ok && state1'.ok
+            && state2.ok && state2_int.ok && state2'.ok
+    ensures constTimeInvariant(ts', state1', state2');
+    {
+        assert constTimeInvariant(ts_int, state1_int, state2_int);
+        assert taintStateModInvariant(ts, ts_int);
+        assert taintStateModInvariant(ts_int, ts');
+    }
+
+    assert specTaintCheckCode(block.hd, ts, ts_int, fixedTime);
+    assert specTaintCheckBlock(block.tl, ts_int, ts', fixedTime);
+
+    forall state1,state2,state1',state2' |
+        evalBlock(block, state1, state1')
+        && evalBlock(block, state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+    ensures constTimeInvariant(ts', state1', state2');
+    {
+        var state1_int :|
+            evalCode(block.hd, state1, state1_int)
+            && evalBlock(block.tl, state1_int, state1');
+
+        var state2_int :|
+            evalCode(block.hd, state2, state2_int)
+            && evalBlock(block.tl, state2_int, state2');
+
+        assert specTaintCheckCode(block.hd, ts, ts_int, fixedTime);
+        assert specTaintCheckBlock(block.tl, ts_int, ts', fixedTime);
+
+        assert evalCode(block.hd, state1, state1_int);
+        assert evalCode(block.hd, state2, state2_int);
+
+        lemma_FailurePreservedByBlock(block.tl, state1_int, state1');
+        lemma_FailurePreservedByBlock(block.tl, state2_int, state2');
+        assert state1.ok && state1_int.ok;
+        assert state2.ok && state2_int.ok;
+
+        assert taintStateModInvariant(ts, ts_int);
+        assert taintStateModInvariant(ts_int, ts');
+
+        assert constTimeInvariant(ts, state1, state2);
+        assert constTimeInvariant(ts_int, state1_int, state2_int);
+        assert constTimeInvariant(ts', state1', state2');
+    }
+
+    forall
+    ensures blockPostconditions(block, ts, ts', fixedTime)
+    {
+    }
+}
+
+method combineTaints<T>(t1:map<T,taint>, t2:map<T,taint>)
+    returns (t:map<T,taint>)
+
+    ensures  specCombineTaints(t1, t2, t)
+    ensures forall e :: e in t1 ==> e in t;
+    ensures forall e :: e in t2 ==> e in t;
+{
+    var keysT1 := domain(t1);
+    var keysT2 := domain(t2);
+    var keys := keysT1 + keysT2;
+    var keys' := keys;
+
+    t := map[];
+
+    while (keys' != {})
+        invariant forall k :: k in keys' ==> k in keys;
+        invariant specCombineTaints(t1, t2, t)
+        invariant forall e :: e in t1 ==> (e in t || e in keys');
+        invariant forall e :: e in t2 ==> (e in t || e in keys');
+        decreases |keys'|
+    {
+        var e :| e in keys';
+        var taint := Public;
+
+        if e in t1 && e in t2 {
+            taint := t1[e];
+            taint := mergeTaint(taint, t2[e]);
+        } else if e in t1 && e !in t2 {
+            taint := Secret;
+        } else if e !in t1 && e in t2 {
+            taint := Secret;
+        }
+
+        t := t[e := taint];
+        keys' := keys' - { e };
+    }
+}
+
+method combineTaintStates(ghost ts:taintState, ts1:taintState, ts2:taintState)
+    returns (ts':taintState)
+    requires taintStateModInvariant(ts, ts1);
+    requires taintStateModInvariant(ts, ts2);
+    ensures taintStateModInvariant(ts1, ts');
+    ensures taintStateModInvariant(ts2, ts');
+    ensures taintStateModInvariant(ts, ts');
+    ensures specCombineTaintStates(ts1, ts2, ts');
+{
+    var regTaint := combineTaints<x86reg>(ts1.regTaint, ts2.regTaint);
+    var stackTaint := combineTaints<int>(ts1.stackTaint, ts2.stackTaint);
+    var xmmTaint := combineTaints<int>(ts1.xmmTaint, ts2.xmmTaint);
+    var flagTaint := mergeTaint(ts1.flagsTaint, ts2.flagsTaint);
+
+    ts' := TaintState(stackTaint, regTaint, xmmTaint, flagTaint);
+}
+
+lemma{:fuel evalCode, 0}{:fuel evalWhile, 0} lemma_checkIfLoopConsumesFixedTimeHelper(
+    pred:obool,
+    body:code,
+    ts:taintState,
+    state1:state,
+    state2:state,
+    state1':state,
+    state2':state,
+    n1:nat,
+    n2:nat
+    )
+    requires state1.ok;
+    requires state1'.ok;
+    requires state2.ok;
+    requires state2'.ok;
+    requires specOperandTaint64(pred.o1, ts).Public?;
+    requires specOperandTaint64(pred.o2, ts).Public?;
+    requires specOperandDoesNotUseSecrets(pred.o1, ts);
+    requires specOperandDoesNotUseSecrets(pred.o2, ts);
+    requires constTimeInvariant(ts, state1, state2);
+    requires evalWhile(pred, body, n1, state1, state1');
+    requires evalWhile(pred, body, n2, state2, state2');
+    requires forall pre_guard_state1:state, pre_guard_state2:state, loop_start1:state, loop_start2:state, loop_end1:state, loop_end2:state
+                    {:trigger evalCode(body, loop_start1, loop_end1), evalCode(body, loop_start2, loop_end2), branchRelation(pre_guard_state1, loop_start1, true), branchRelation(pre_guard_state2, loop_start2, true), constTimeInvariant(ts, loop_end1, loop_end2)}
+                    ::
+                    pre_guard_state1.ok
+                 && pre_guard_state2.ok
+                 && loop_end1.ok
+                 && loop_end2.ok
+                 && ValidSourceOperand(pre_guard_state1, 64, pred.o1)
+                 && ValidSourceOperand(pre_guard_state1, 64, pred.o2)
+                 && ValidSourceOperand(pre_guard_state2, 64, pred.o1)
+                 && ValidSourceOperand(pre_guard_state2, 64, pred.o2)
+                 && evalOBool(pre_guard_state1, pred)
+                 && evalOBool(pre_guard_state2, pred)
+                 && branchRelation(pre_guard_state1, loop_start1, true)
+                 && evalCode(body, loop_start1, loop_end1)
+                 && branchRelation(pre_guard_state2, loop_start2, true)
+                 && evalCode(body, loop_start2, loop_end2)
+                 && constTimeInvariant(ts, pre_guard_state1, pre_guard_state2)
+                 ==> constTimeInvariant(ts, loop_end1, loop_end2);
+    decreases n1;
+    ensures  constTimeInvariant(ts, state1', state2');
+{
+    lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, pred.o1);
+    lemma_ValuesOfPublic64BitOperandAreSame(ts, state1, state2, pred.o2);
+    assert evalOBool(state1, pred) == evalOBool(state2, pred);
+
+    if n1 == 0 {
+        return;
+    }
+
+    assert n2 != 0;
+
+    var loop_start1:state, loop_end1:state :|    evalOBool(state1, pred)
+                                            && branchRelation(state1, loop_start1, true)
+                                            && evalCode(body, loop_start1, loop_end1)
+                                            && evalWhile(pred, body, n1 - 1, loop_end1, state1');
+
+    var loop_start2:state, loop_end2:state :|    evalOBool(state2, pred)
+                                            && branchRelation(state2, loop_start2, true)
+                                            && evalCode(body, loop_start2, loop_end2)
+                                            && evalWhile(pred, body, n2 - 1, loop_end2, state2');
+
+    assert loop_end1.ok && loop_end2.ok by
+    {
+        assert{:fuel evalWhile, 1} loop_end1.ok;
+        assert{:fuel evalWhile, 1} loop_end2.ok;
+    }
+    lemma_checkIfLoopConsumesFixedTimeHelper(pred, body, ts, loop_end1, loop_end2, state1', state2', n1-1, n2-1);
+}
+
+method { :timeLimitMultiplier 2 } checkIfLoopConsumesFixedTime(pred:obool, body:code, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    ensures  fixedTime ==> taintStateModInvariant(ts, ts');
+    ensures  fixedTime ==> isConstantTime(While(pred, body), ts);
+    ensures  fixedTime ==> specTaintCheckCode(While(pred, body), ts, ts', fixedTime)
+    ensures  fixedTime ==> isLeakageFree(While(pred, body), ts, ts');
+    decreases *
+{
+    ts' := ts;
+    var done := false;
+    var next_ts:taintState, combined_ts:taintState, o1:taint, o2:taint, predTaint:taint, o1Public:bool, o2Public:bool;
+
+    while (!done)
+        invariant taintStateModInvariant(ts, ts');
+        invariant taintStateSubset(ts, ts');
+        invariant done ==> specOperandTaint64(pred.o1, ts').Public?;
+        invariant done ==> specOperandTaint64(pred.o2, ts').Public?;
+        invariant done ==> specOperandDoesNotUseSecrets(pred.o1, ts');
+        invariant done ==> specOperandDoesNotUseSecrets(pred.o2, ts');
+        invariant done ==>
+                   forall pre_guard_state1:state, pre_guard_state2:state, loop_start1:state, loop_start2:state, loop_end1:state, loop_end2:state ::
+                        pre_guard_state1.ok
+                     && pre_guard_state2.ok
+                     && loop_end1.ok
+                     && loop_end2.ok
+                     && ValidSourceOperand(pre_guard_state1, 64, pred.o1)
+                     && ValidSourceOperand(pre_guard_state1, 64, pred.o2)
+                     && ValidSourceOperand(pre_guard_state2, 64, pred.o1)
+                     && ValidSourceOperand(pre_guard_state2, 64, pred.o2)
+                     && evalOBool(pre_guard_state1, pred)
+                     && evalOBool(pre_guard_state2, pred)
+                     && branchRelation(pre_guard_state1, loop_start1, true)
+                     && evalCode(body, loop_start1, loop_end1)
+                     && branchRelation(pre_guard_state2, loop_start2, true)
+                     && evalCode(body, loop_start2, loop_end2)
+                     && constTimeInvariant(ts', pre_guard_state1, pre_guard_state2)
+                     ==> constTimeInvariant(ts', loop_end1, loop_end2);
+        decreases *;
+    {
+        o1 := operandTaint64(pred.o1, ts');
+        o2 := operandTaint64(pred.o2, ts');
+        predTaint := mergeTaint(o1, o2);
+
+        if predTaint.Secret? {
+            fixedTime := false;
+            return;
+        }
+
+        assert specOperandTaint64(pred.o1, ts').Public?;
+        assert specOperandTaint64(pred.o2, ts').Public?;
+
+        o1Public := operandDoesNotUseSecrets(pred.o1, ts');
+        if o1Public == false {
+            fixedTime := false;
+            return;
+        }
+
+        o2Public := operandDoesNotUseSecrets(pred.o2, ts');
+        if o2Public == false {
+            fixedTime := false;
+            return;
+        }
+
+        fixedTime, next_ts := checkIfCodeConsumesFixedTime(body, ts');
+        if !fixedTime {
+            return;
+        }
+
+        combined_ts := combineTaintStates(ts, ts', next_ts);
+        lemma_CombiningTaintStatesProducesSuperset(ts', next_ts, combined_ts);
+
+        if (combined_ts == ts') {
+            done := true;
+            forall pre_guard_state1:state, pre_guard_state2:state, loop_start1:state, loop_start2:state, loop_end1:state, loop_end2:state |
+                            pre_guard_state1.ok
+                         && pre_guard_state2.ok
+                         && constTimeInvariant(ts', pre_guard_state1, pre_guard_state2)
+                         && loop_end1.ok
+                         && loop_end2.ok
+                         && ValidSourceOperand(pre_guard_state1, 64, pred.o1)
+                         && ValidSourceOperand(pre_guard_state1, 64, pred.o2)
+                         && ValidSourceOperand(pre_guard_state2, 64, pred.o1)
+                         && ValidSourceOperand(pre_guard_state2, 64, pred.o2)
+                         && evalOBool(pre_guard_state1, pred)
+                         && evalOBool(pre_guard_state2, pred)
+                         && branchRelation(pre_guard_state1, loop_start1, true)
+                         && evalCode(body, loop_start1, loop_end1)
+                         && branchRelation(pre_guard_state2, loop_start2, true)
+                         && evalCode(body, loop_start2, loop_end2)
+                ensures constTimeInvariant(ts', loop_end1, loop_end2);
+            {
+                assert constTimeInvariant(combined_ts, loop_start1, loop_start2);
+                lemma_FailurePreservedByCode(body, loop_start1, loop_end1);
+                lemma_FailurePreservedByCode(body, loop_start2, loop_end2);
+                assert loop_start1.ok;
+                assert loop_start2.ok;
+                assert constTimeInvariant(next_ts, loop_end1, loop_end2);
+                lemma_TaintSupersetImpliesPublicValuesAreSameIsPreserved(next_ts, combined_ts, loop_end1, loop_end2);
+                assert constTimeInvariant(combined_ts, loop_end1, loop_end2);
+            }
+        }
+        else {
+            ts' := combined_ts;
+        }
+    }
+
+    fixedTime := true;
+
+    forall state1, state2, state1', state2' |
+           evalCode(While(pred, body), state1, state1')
+        && evalCode(While(pred, body), state2, state2')
+        && state1.ok && state1'.ok
+        && state2.ok && state2'.ok
+        && constTimeInvariant(ts, state1, state2)
+        ensures constTimeInvariant(ts', state1', state2');
+        ensures state1'.trace == state2'.trace;
+    {
+        var c := While(pred, body);
+        assert evalCode(c, state1, state1');
+        assert exists n:nat :: evalWhile(c.whileCond, c.whileBody, n, state1, state1');
+        var n1:nat :| evalWhile(pred, body, n1, state1, state1');
+        assert evalCode(c, state2, state2');
+        assert exists n:nat :: evalWhile(c.whileCond, c.whileBody, n, state2, state2');
+        var n2:nat :| evalWhile(pred, body, n2, state2, state2');
+        lemma_TaintSupersetImpliesPublicValuesAreSameIsPreserved(ts, ts', state1, state2);
+        lemma_checkIfLoopConsumesFixedTimeHelper(pred, body, ts', state1, state2, state1', state2', n1, n2);
+    }
+}
+
+method checkIfCodeConsumesFixedTime(code:code, ts:taintState)
+    returns (fixedTime:bool, ts':taintState)
+
+    ensures fixedTime ==> specTaintCheckCode(code, ts, ts', fixedTime);
+    ensures fixedTime ==> isConstantTime(code, ts);
+    ensures fixedTime ==> taintStateModInvariant(ts, ts');
+    ensures fixedTime ==> isLeakageFree(code, ts, ts');
+
+    decreases *
+{
+    match code {
+        case Ins(ins) =>
+            if (ValidRegsInXmmIns(ins)) {
+                fixedTime, ts' := checkIfInstructionConsumesFixedTime(ins, ts);
+                if fixedTime == true {
+                    assert insPostconditions(ins, ts, ts', fixedTime);
+                }
+            } else {
+                fixedTime := false;
+                return;
+            }
+
+        case Block(block) =>
+            fixedTime, ts' := checkIfBlockConsumesFixedTime(block, ts);
+
+            if (fixedTime == false) {
+                return;
+            }
+
+            assert specTaintCheckBlock(block, ts, ts', fixedTime);
+
+            forall state1, state2, state1', state2' |
+                (evalBlock(block, state1, state1')
+                && evalBlock(block, state2, state2')
+                && state1.ok && state1'.ok
+                && state2.ok && state2'.ok
+                && constTimeInvariant(ts, state1, state2))
+            ensures constTimeInvariant(ts', state1', state2');
+            ensures state1'.trace == state2'.trace;
+            {
+            }
+
+        case IfElse(pred, ift, iff) =>
+            var o1 := operandTaint64(pred.o1, ts);
+            var o2 := operandTaint64(pred.o2, ts);
+            var predTaint := mergeTaint(o1, o2);
+
+            ts' := ts;
+            if (o1.Secret? || o2.Secret?)
+            {
+                fixedTime := false;
+                return;
+            }
+
+            var o1Public := operandDoesNotUseSecrets(pred.o1, ts);
+            if o1Public == false {
+                fixedTime := false;
+                return;
+            }
+
+            var o2Public := operandDoesNotUseSecrets(pred.o2, ts);
+            if o2Public == false {
+                fixedTime := false;
+                return;
+            }
+
+            var validIft:bool, validIff:bool;
+            var tsIft:taintState, tsIff:taintState;
+
+            validIft, tsIft := checkIfCodeConsumesFixedTime(ift, ts);
+            if (validIft == false)
+            {
+                fixedTime := false;
+                return;
+            }
+
+            validIff, tsIff := checkIfCodeConsumesFixedTime(iff, ts);
+            if (validIff == false)
+            {
+                fixedTime := false;
+                return;
+            }
+
+            fixedTime := true;
+            ts' := combineTaintStates(ts, tsIft, tsIff);
+            lemma_ifElse(pred, ift, iff, fixedTime, ts, tsIft, tsIff, ts');
+            assert isLeakageFree(IfElse(pred, ift, iff), ts, ts');
+
+        case While(pred, body) =>
+            fixedTime, ts' := checkIfLoopConsumesFixedTime(pred, body, ts);
+
+            forall
+            ensures fixedTime ==> specTaintCheckCode(code, ts, ts', fixedTime)
+            {
+            }
+    }
+}
+
+method {:timeLimitMultiplier 2} checkIfCodeisLeakageFree(code:code, ts:taintState, tsExpected:taintState) returns (b:bool)
+    ensures b ==> isLeakageFree(code, ts, tsExpected);
+    ensures b ==> isConstantTime(code, ts);
+
+    decreases *
+{
+    var fixedTime, ts' := checkIfCodeConsumesFixedTime(code, ts);
+
+    b := fixedTime;
+
+    if (b) {
+        b := publicTaintsAreAsExpected(tsExpected, ts');
+
+       if (b == false) {
+            return;
+
+        }
+
+        assert  (forall s1, s2, r1, r2 :: isExplicitLeakageFreeGivenStates(code, ts, ts', s1, s2, r1, r2));
+        lemma_ConsequencesOfIsLeakageFreeGivenStates(code, ts, ts');
+        assert forall s1, s2, r1, r2 :: (evalCode(code, s1, r1)
+            && evalCode(code, s2, r2)
+            && s1.ok && r1.ok
+            && s2.ok && r2.ok
+            && constTimeInvariant(ts, s1, s2))
+            ==> publicValuesAreSame(ts', r1, r2);
+        assert forall s1, s2, r1, r2 :: (evalCode(code, s1, r1)
+            && evalCode(code, s2, r2)
+            && s1.ok && r1.ok
+            && s2.ok && r2.ok
+            && constTimeInvariant(ts, s1, s2)
+            && publicValuesAreSame(ts', r1, r2)) ==> publicValuesAreSame(tsExpected, r1, r2);
+        assert forall s1, s2, r1, r2 :: (evalCode(code, s1, r1)
+            && evalCode(code, s2, r2)
+            && s1.ok && r1.ok
+            && s2.ok && r2.ok
+            && constTimeInvariant(ts, s1, s2))
+            ==> publicValuesAreSame(tsExpected, r1, r2);
+        assert isLeakageFree(code, ts, tsExpected);
+    }
+}
+
+}

--- a/src/arch/x64/leakage.s.dfy
+++ b/src/arch/x64/leakage.s.dfy
@@ -1,0 +1,105 @@
+include "def.s.dfy"
+module x64_leakage_s {
+
+import opened x64_def_s
+
+datatype taintState = TaintState(stackTaint:map<int,taint>,
+        regTaint:map<x86reg,taint>, xmmTaint:map<int,taint>, flagsTaint:taint)
+
+datatype Value =
+    Operand(o:operand)
+    | Predicate(p:obool)
+
+predicate publicXMMValuesAreSame(ts:taintState, s1:state, s2:state)
+{
+    forall x :: x in ts.xmmTaint && ts.xmmTaint[x].Public?
+        ==> x in s1.xmms
+         && x in s2.xmms
+         && s1.xmms[x] == s2.xmms[x]
+}
+
+predicate publicFlagValuesAreSame(ts:taintState, s1:state, s2:state)
+{
+    ts.flagsTaint == Public ==>
+        (s1.flags == s2.flags)
+}
+
+predicate publicHeapValuesAreSame(s1:state, s2:state)
+{
+    forall h :: h in s1.heap && s1.heap[h].t.Public?
+        ==> (h in s2.heap && s1.heap[h] == s2.heap[h])
+}
+
+predicate publicRegisterValuesAreSame(ts:taintState, s1:state, s2:state)
+{
+    forall r :: r in ts.regTaint && ts.regTaint[r].Public?
+        ==> r in s1.regs
+         && r in s2.regs
+         && s1.regs[r] == s2.regs[r]
+}
+
+predicate publicStackValuesAreSame(ts:taintState, s1:state, s2:state)
+{
+    forall s :: s in ts.stackTaint && ts.stackTaint[s].Public?
+        ==> |s1.stack| > 0
+         && |s2.stack| > 0
+         && s in s1.stack[0]
+         && s in s2.stack[0]
+         && s1.stack[0][s] == s2.stack[0][s]
+}
+
+predicate publicValuesAreSame(ts:taintState, s1:state, s2:state)
+{
+       publicHeapValuesAreSame(s1, s2)
+    && publicXMMValuesAreSame(ts, s1, s2)
+    && publicFlagValuesAreSame(ts, s1, s2)
+    && publicStackValuesAreSame(ts, s1, s2)
+    && publicRegisterValuesAreSame(ts, s1, s2)
+}
+
+predicate constTimeInvariant(ts:taintState, s:state, s':state)
+{
+       publicValuesAreSame(ts, s, s')
+    && s.trace == s'.trace
+}
+
+predicate isConstantTimeGivenStates(code:code, ts:taintState, s1:state,
+        s2:state, r1:state, r2:state)
+{
+    (evalCode(code, s1, r1)
+    && evalCode(code, s2, r2)
+    && s1.ok && r1.ok
+    && s2.ok && r2.ok
+    && constTimeInvariant(ts, s1, s2))
+        ==> r1.trace == r2.trace
+}
+
+predicate isConstantTime(code:code, ts:taintState)
+{
+    forall s1, s2, r1, r2 ::
+        isConstantTimeGivenStates(code, ts, s1, s2, r1, r2)
+}
+
+predicate isExplicitLeakageFreeGivenStates(code:code, ts:taintState, ts':taintState, s1:state,
+        s2:state, r1:state, r2:state)
+{
+      (evalCode(code, s1, r1)
+    && evalCode(code, s2, r2)
+    && s1.ok && r1.ok
+    && s2.ok && r2.ok
+    && constTimeInvariant(ts, s1, s2))
+    ==> publicValuesAreSame(ts', r1, r2)
+}
+
+predicate isExplicitLeakageFree(code:code, ts:taintState, ts':taintState)
+{
+    forall s1, s2, r1, r2 ::
+        isExplicitLeakageFreeGivenStates(code, ts, ts', s1, s2, r1, r2)
+}
+
+predicate isLeakageFree(code:code, ts:taintState, ts':taintState)
+{
+       isConstantTime(code, ts)
+    && isExplicitLeakageFree(code, ts, ts')
+}
+}

--- a/src/arch/x86/leakage-helpers.i.dfy
+++ b/src/arch/x86/leakage-helpers.i.dfy
@@ -2040,27 +2040,27 @@ lemma lemma_ifElse(pred:obool, ift:code, iff:code, fixedTime:bool,
 
 predicate method publicXMMTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall x :: x in tsAnalysis.xmmTaint && tsAnalysis.xmmTaint[x].Public?
-        ==> (x in tsExpected.xmmTaint && tsExpected.xmmTaint[x].Public?)
+    forall x :: x in tsExpected.xmmTaint && tsExpected.xmmTaint[x].Public?
+        ==> (x in tsAnalysis.xmmTaint && tsAnalysis.xmmTaint[x].Public?)
 }
  
 predicate method publicFlagTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 
 {
-    tsAnalysis.flagsTaint == Public 
-        ==> tsExpected.flagsTaint == Public
+    tsExpected.flagsTaint == Public
+        ==> tsAnalysis.flagsTaint == Public
 }
  
 predicate method publicStackTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall s :: s in tsAnalysis.stackTaint && tsAnalysis.stackTaint[s].Public?
-        ==> (s in tsExpected.stackTaint && tsExpected.stackTaint[s].Public?)
+    forall s :: s in tsExpected.stackTaint && tsExpected.stackTaint[s].Public?
+        ==> (s in tsAnalysis.stackTaint && tsAnalysis.stackTaint[s].Public?)
 }
  
 predicate method publicRegisterTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)
 {
-    forall r :: r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?
-        ==> (r in tsExpected.regTaint && tsExpected.regTaint[r].Public?)
+    forall r :: r in tsExpected.regTaint && tsExpected.regTaint[r].Public?
+        ==> (r in tsAnalysis.regTaint && tsAnalysis.regTaint[r].Public?)
 }
 
 predicate method publicTaintsAreAsExpected(tsAnalysis:taintState, tsExpected:taintState)

--- a/src/arch/x86/leakage.i.dfy
+++ b/src/arch/x86/leakage.i.dfy
@@ -1398,7 +1398,7 @@ method {:timeLimitMultiplier 2} checkIfCodeisLeakageFree(code:code, ts:taintStat
     b := fixedTime;
 
     if (b) {
-        b := publicTaintsAreAsExpected(tsExpected, ts');
+        b := publicTaintsAreAsExpected(ts', tsExpected);
 
        if (b == false) {
             return;

--- a/src/lib/util/operations.i.dfy
+++ b/src/lib/util/operations.i.dfy
@@ -146,6 +146,10 @@ lemma lemma_BitwiseXorWithItself(x:uint32)
     }
 }
 
+// FIXME: Add proof of lemma.
+lemma lemma_BitwiseXor64WithItself(x:uint64)
+    ensures BitwiseXor64(x, x) == 0;
+
 lemma lemma_BitXorAssociativity(x:bv32, y:bv32, z:bv32)
     ensures BitXor(x, BitXor(y, z)) == BitXor(BitXor(x, y), z);
 {

--- a/src/lib/util/operations.i.dfy
+++ b/src/lib/util/operations.i.dfy
@@ -46,12 +46,46 @@ lemma lemma_WordToBitsPreservesZeroness(w:uint32)
     }
 }
 
+lemma lemma_WordToBitsPreservesZeroness64(w:uint64)
+    ensures  w == 0 <==> WordToBits64(w) == 0;
+{
+    reveal_WordToBits64();
+    lemma_WordToBitsToWord64(w);
+
+    if w == 0 {
+        calc {
+            WordToBits64(w);
+            w as bv64;
+            0 as bv64;
+            0;
+        }
+    }
+    else {
+        assert WordToBits64(w) != 0;
+    }
+
+    if WordToBits64(w) == 0 {
+        assert w == 0;
+    }
+    else {
+        assert w != 0;
+    }
+}
+
 lemma lemma_BitsToWordPreservesZeroness(b:bv32)
     ensures  b == 0 <==> BitsToWord(b) == 0;
 {
     var w := BitsToWord(b);
     lemma_WordToBitsPreservesZeroness(w);
     lemma_BitsToWordToBits(b);
+}
+
+lemma lemma_BitsToWordPreservesZeroness64(b:bv64)
+    ensures  b == 0 <==> BitsToWord64(b) == 0;
+{
+    var w := BitsToWord64(b);
+    lemma_WordToBitsPreservesZeroness64(w);
+    lemma_BitsToWordToBits64(b);
 }
 
 lemma lemma_BitsAndWordConversions()
@@ -133,6 +167,12 @@ lemma lemma_BitXorWithItself(x:bv32)
     reveal_BitXor();
 }
 
+lemma lemma_BitXorWithItself64(x:bv64)
+    ensures BitXor64(x, x) == 0;
+{
+    reveal_BitXor64();
+}
+
 lemma lemma_BitwiseXorWithItself(x:uint32)
     ensures BitwiseXor(x, x) == 0;
 {
@@ -146,9 +186,18 @@ lemma lemma_BitwiseXorWithItself(x:uint32)
     }
 }
 
-// FIXME: Add proof of lemma.
 lemma lemma_BitwiseXor64WithItself(x:uint64)
     ensures BitwiseXor64(x, x) == 0;
+{
+    calc {
+        BitwiseXor64(x, x);
+        BitsToWord64(BitXor64(WordToBits64(x), WordToBits64(x)));
+            { lemma_BitXorWithItself64(WordToBits64(x)); }
+        BitsToWord64(0);
+            { lemma_BitsToWordPreservesZeroness64(0); }
+        0;
+    }
+}
 
 lemma lemma_BitXorAssociativity(x:bv32, y:bv32, z:bv32)
     ensures BitXor(x, BitXor(y, z)) == BitXor(BitXor(x, y), z);


### PR DESCRIPTION
These patches extend the previous ones so that publicTaintsAreAsExpected() is invoked with the right arguments. Instead of checking whether the taint state produced by the analysis is a subset of the expected taint state, the new code now checks whether the expected taint state is a subset of the taint state produced by the analysis. The old (incorrect) code still worked because the leakage implementation incorrectly swapped the arguments.