### PR TITLE
Introduction of {:codeOnly} attribute

### DIFF
--- a/tools/Vale/src/Vale.fsproj
+++ b/tools/Vale/src/Vale.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -74,8 +74,13 @@ fsyacc --module "Parse" -v $(ProjectDir)parse.fsy -o parse.fs</PreBuildEvent>
       <Visible>false</Visible>
       <Link>lex.fs</Link>
     </Compile>
+    <Compile Include="typechecker.fs" />
     <Compile Include="transform.fs" />
-    <Compile Include="emit_common.fs" />
+    <Compile Include="emit_common_base.fs" />
+    <Compile Include="emit_common_lemmas.fs" />
+    <Compile Include="emit_common_quick_code.fs" />
+    <Compile Include="emit_common_quick_export.fs" />
+    <Compile Include="emit_common_top.fs" />
     <Compile Include="emit_dafny_text.fs" />
     <Compile Include="emit_dafny_direct.fs" />
     <Compile Include="emit_fstar_text.fs" />

--- a/tools/Vale/src/emit_common_lemmas.fs
+++ b/tools/Vale/src/emit_common_lemmas.fs
@@ -581,6 +581,7 @@ let build_proc (envBody:env) (env:env) (loc:loc) (p:proc_decl):decls =
   let isOperand = List_mem_assoc (Id "operand") p.pattrs in
   let codeName prefix = Reserved ("code_" + prefix + (string_of_id p.pname)) in
   let isQuick = is_quick_body p.pattrs in
+  let isCodeOnly = List_mem_assoc (Id "codeOnly") p.pattrs in
   let reqs =
     List.collect (fun (loc, s) ->
         match s with
@@ -632,6 +633,6 @@ let build_proc (envBody:env) (env:env) (loc:loc) (p:proc_decl):decls =
           if isQuick then
             Emit_common_quick_code.build_qcode envBody loc p stmts
           else []
-        fCodes @ (if !no_lemmas then [] else quickDecls @ pLemma)
+        fCodes @ (if !no_lemmas || isCodeOnly then [] else quickDecls @ pLemma)
     in
   bodyDecls //@ blockLemmaDecls

--- a/tools/Vale/src/emit_common_top.fs
+++ b/tools/Vale/src/emit_common_top.fs
@@ -55,10 +55,11 @@ let build_one_decl (verify:bool) (loc:loc) (envr:env, envBody:env, d:decl):decls
     | DProc p ->
         let isVerify = List_mem_assoc (Id "verify") p.pattrs in
         let isQuick = List_mem_assoc (Id "quick") p.pattrs in
+        let isCodeOnly = List_mem_assoc (Id "codeOnly") p.pattrs in
         if verify then
           if isVerify && not !disable_verify then err "{:verify} attribute is only allowed with -disableVerify command line flag" else
           let ds_p = Emit_common_lemmas.build_proc envBody envr loc p in
-          let ds_q = if isQuick && not !no_lemmas then Emit_common_quick_export.build_proc envr loc p else [] in
+          let ds_q = if isQuick && not !no_lemmas && not isCodeOnly then Emit_common_quick_export.build_proc envr loc p else [] in
           let comment (s:string) : loc * decl =
             let isPublic = attrs_get_bool (Id "public") false p.pattrs in
             let attrs = if isPublic then [(Id "interface", []); (Id "implementation", [])] else [] in

--- a/tools/Vale/src/transform.fs
+++ b/tools/Vale/src/transform.fs
@@ -1182,6 +1182,7 @@ let transform_proc (env:env) (loc:loc) (p:proc_decl):transformed =
   let isInstruction = List_mem_assoc (Id "instruction") p.pattrs in
   let isAlreadyModOk = List_mem_assoc (Id "already_has_mod_ok") p.pattrs in
   let isQuick = is_quick_body p.pattrs in
+  let isCodeOnly = List_mem_assoc (Id "codeOnly") p.pattrs in
   let preserveSpecs =
     List.collect
       (fun spec ->
@@ -1261,7 +1262,7 @@ let transform_proc (env:env) (loc:loc) (p:proc_decl):transformed =
   let envpIn = {envpIn with abstractOld = true} in
   let envp = envpIn in
   let envp = {envp with ids = List.fold (addParam true) envp.ids p.prets} in
-  let envp = {envp with checkMods = isFrame} in
+  let envp = {envp with checkMods = isFrame && not isCodeOnly} in
   let envp = {envp with abstractOld = false} in
   let specs = List_mapSnd (rewrite_vars_spec envpIn envp) pspecs in
   let specs = List_mapSnd (resolve_overload_spec envpIn envp) specs in

--- a/tools/Vale/test/test.vaf
+++ b/tools/Vale/test/test.vaf
@@ -106,8 +106,6 @@ procedure Test() returns(ghost g:int)
 
 procedure CodeOnlyProcedure()
   {:codeOnly}
-  modifies
-    efl; rax; /* REVIEW: Is it possible for us to no longer require these? */
   ensures
     false; /* Since we are only generating the code, the postcondition is irrelevant */
 {

--- a/tools/Vale/test/test.vaf
+++ b/tools/Vale/test/test.vaf
@@ -103,3 +103,19 @@ procedure Test() returns(ghost g:int)
   assert g == 12;
   assert (fun(x:int) x + 1)(12) == 13;
 }
+
+procedure CodeOnlyProcedure()
+  {:codeOnly}
+  modifies
+    efl; rax; /* REVIEW: Is it possible for us to no longer require these? */
+  ensures
+    false; /* Since we are only generating the code, the postcondition is irrelevant */
+{
+    Add64Wrap(rax, 1);
+    Add64Wrap(rax, 1);
+}
+
+#verbatim{:implementation}
+let test_codeonlyprocedure1 () : Tot unit =
+  assert (va_code_CodeOnlyProcedure == va_code_CodeOnlyProcedure) (* Check that it is defined *)
+#endverbatim


### PR DESCRIPTION
This PR introduces the `{:codeOnly}` attribute for procedures. This attribute makes vale produce _only_ a `code` object for the procedure, and to _not_ verify anything else about it. This means that this procedure _cannot_ be used in another procedure (since the `va_lemma_`/`va_qattr`/etc for it won't be found), however, the produced code object may be used by other tools.

PS: This PR also fixes up the `Vale.fsproj` to make sure it calls out to the correct `.fs` files.