### PR TITLE
Introduction of [va_codegen_success_]

### DIFF
--- a/fstar/code/arch/x64/X64.Vale.Decls.fst
+++ b/fstar/code/arch/x64/X64.Vale.Decls.fst
@@ -15,6 +15,11 @@ let ins = S.ins
 type ocmp = S.ocmp
 type va_fuel = nat
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let mul_nat_helper x y =
   FStar.Math.Lemmas.nat_times_nat_is_nat x y
 

--- a/fstar/code/arch/x64/X64.Vale.Decls.fsti
+++ b/fstar/code/arch/x64/X64.Vale.Decls.fsti
@@ -60,6 +60,11 @@ unfold let va_cmp = operand
 unfold let va_register = reg
 unfold let va_operand_xmm = xmm
 
+val va_pbool : Type0
+val va_ttrue : unit -> va_pbool
+val va_ffalse : string -> va_pbool
+val va_pbool_and : va_pbool -> va_pbool -> va_pbool
+
 val mul_nat_helper (x y:nat) : Lemma (x `op_Multiply` y >= 0)
 [@va_qattr] unfold let va_mul_nat (x y:nat) : nat =
   mul_nat_helper x y;

--- a/fstar/specs/defs/Vale.Def.PossiblyMonad.fst
+++ b/fstar/specs/defs/Vale.Def.PossiblyMonad.fst
@@ -1,0 +1,124 @@
+module Vale.Def.PossiblyMonad
+
+/// Similar to the [maybe] monad in Haskell (which is like the
+/// [option] type in F* and OCaml), but instead, we also store the
+/// reason for the error when the error occurs.
+
+type possibly 'a =
+  | Ok : v:'a -> possibly 'a
+  | Err : reason:string -> possibly 'a
+
+unfold let return (#a:Type) (x:a) : possibly a =
+  Ok x
+
+unfold let bind (#a #b:Type) (x:possibly a) (f:a -> possibly b) : possibly b =
+  match x with
+  | Err s -> Err s
+  | Ok x' -> f x'
+
+unfold let fail_with (#a:Type) (s:string) : possibly a = Err s
+
+unfold let unimplemented (#a:Type) (s:string) : possibly a = fail_with ("Unimplemented: " ^ s)
+
+(** Allows moving to a "looser" monad type, always *)
+unfold
+let loosen (#t1:Type) (#t2:Type{t1 `subtype_of` t2})
+    (x:possibly t1) : possibly t2 =
+  match x with
+  | Ok x' -> Ok x'
+  | Err s -> Err s
+
+(** Allows moving to a "tighter" monad type, as long as the monad is
+    guaranteed statically to be within this tighter type *)
+unfold
+let tighten (#t1:Type) (#t2:Type{t2 `subtype_of` t1})
+    (x:possibly t1{Ok? x ==> Ok?.v x `has_type` t2}) : possibly t2 =
+  match x with
+  | Ok x' -> Ok x'
+  | Err s -> Err s
+
+(** [pbool] is a type that can be used instead of [bool] to hold on to
+    a reason whenever it is [false]. To convert from a [pbool] to a
+    bool, see [!!]. *)
+unfold
+type pbool = possibly unit
+
+(** [!!x] coerces a [pbool] into a [bool] by discarding any reason it
+    holds on to and instead uses it solely as a boolean. *)
+unfold
+let (!!) (x:pbool) : bool = Ok? x
+
+(** [ttrue] is just the same as [true] but for a [pbool] *)
+unfold
+let ttrue : pbool = Ok ()
+
+(** [ffalse] is the same as [false] but is for a [pbool] and thus requires a reason for being false. *)
+unfold
+let ffalse (reason:string) : pbool = Err reason
+
+(** [b /- r] is the same as [b] but as a [pbool] that is set to reason [r] if [b] is false. *)
+unfold
+let (/-) (b:bool) (reason:string) : pbool =
+  if b then
+    ttrue
+  else
+    ffalse reason
+
+(** [p /+> r] is the same as [p] but also appends [r] to the reason if it was false. *)
+unfold
+let (/+>) (p:pbool) (r:string) : pbool =
+  match p with
+  | Ok () -> Ok ()
+  | Err rr -> Err (rr ^ r)
+
+(** [p /+< r] is the same as [p] but also prepends [r] to the reason if it was false. *)
+unfold
+let (/+<) (p:pbool) (r:string) : pbool =
+  match p with
+  | Ok () -> Ok ()
+  | Err rr -> Err (r ^ rr)
+
+(** [&&.] is a short-circuiting logical-and. *)
+let (&&.) (x y:pbool) : pbool =
+  match x with
+  | Ok () -> y
+  | Err reason -> Err reason
+
+(** [ ||. ] is a short-circuiting logical-or *)
+let ( ||. ) (x y:pbool) : pbool =
+  match x with
+  | Ok () -> Ok ()
+  | Err rx -> y /+< (rx ^ " and ")
+
+(** [for_all f l] runs [f] on all the elements of [l] and performs a
+    short-circuit logical-and of all the results *)
+let rec for_all (f : 'a -> pbool) (l : list 'a) : pbool =
+  match l with
+  | [] -> ttrue
+  | x :: xs -> f x &&. for_all f xs
+
+(** Change from a [forall] to a [for_all] *)
+let rec lemma_for_all_intro (f : 'a -> pbool) (l : list 'a) :
+  Lemma
+    (requires (forall x. {:pattern (x `List.Tot.memP` l)} (x `List.Tot.memP` l) ==> !!(f x)))
+    (ensures !!(for_all f l)) =
+  let open FStar.List.Tot in
+  let aux l x :
+    Lemma
+      (requires (x `memP` l ==> !!(f x)))
+      (ensures (Cons? l /\ x `memP` tl l ==> !!(f x))) = () in
+  match l with
+  | [] -> ()
+  | x :: xs ->
+    FStar.Classical.forall_intro (FStar.Classical.move_requires (aux l));
+    lemma_for_all_intro f xs
+
+(** Change from a [for_all] to a [forall] *)
+let rec lemma_for_all_elim (f : 'a -> pbool) (l : list 'a) :
+  Lemma
+    (requires !!(for_all f l))
+    (ensures (forall x. {:pattern (x `List.Tot.memP` l)} (x `List.Tot.memP` l) ==> !!(f x))) =
+  match l with
+  | [] -> ()
+  | x :: xs ->
+    lemma_for_all_elim f xs

--- a/tools/Vale/src/Vale.fsproj
+++ b/tools/Vale/src/Vale.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -74,8 +74,13 @@ fsyacc --module "Parse" -v $(ProjectDir)parse.fsy -o parse.fs</PreBuildEvent>
       <Visible>false</Visible>
       <Link>lex.fs</Link>
     </Compile>
+    <Compile Include="typechecker.fs" />
     <Compile Include="transform.fs" />
-    <Compile Include="emit_common.fs" />
+    <Compile Include="emit_common_base.fs" />
+    <Compile Include="emit_common_lemmas.fs" />
+    <Compile Include="emit_common_quick_code.fs" />
+    <Compile Include="emit_common_quick_export.fs" />
+    <Compile Include="emit_common_top.fs" />
     <Compile Include="emit_dafny_text.fs" />
     <Compile Include="emit_dafny_direct.fs" />
     <Compile Include="emit_fstar_text.fs" />

--- a/tools/Vale/src/ast_util.fs
+++ b/tools/Vale/src/ast_util.fs
@@ -10,6 +10,7 @@ let tInt = TInt (NegInf, Inf)
 let tOperand xo = TName (Reserved xo)
 let tState = TName (Reserved "state")
 let tCode = TName (Reserved "code")
+let tPbool = TName (Reserved "pbool")
 let tCodes = TName (Reserved "codes")
 let tFuel = TName (Reserved "fuel")
 let ktype0 = KType bigint.Zero

--- a/tools/Vale/src/emit_common_lemmas.fs
+++ b/tools/Vale/src/emit_common_lemmas.fs
@@ -83,8 +83,7 @@ let rec build_codegen_success_stmt (q:id) (env:env) (s:stmt):exp option list =
   let rec aux (e:exp) (xs:exp option list) : exp option =
     match e with
     | ELoc (_, e) -> aux e xs
-    | EApply (e, _, es, _) when is_id e && is_proc env (id_of_exp e) NotGhost && q <> (id_of_exp e) ->
-      (* REVIEW: We assume correct generation upon recursion *)
+    | EApply (e, _, es, _) when is_id e && is_proc env (id_of_exp e) NotGhost ->
       let x = string_of_id (id_of_exp e) in
       let es = List.filter (fun e -> match e with EOp (Uop UGhostOnly, _, _) -> false | _ -> true) es in
       let es = List.map get_code_exp es in

--- a/tools/Vale/test/forall.vaf
+++ b/tools/Vale/test/forall.vaf
@@ -27,6 +27,11 @@ type va_code =
   | IfElse : ifCond:ocmp -> ifTrue:va_code -> ifFalse:va_code -> va_code
 and va_codes = list va_code
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let va_CNil () = []
 let va_CCons x y = x::y
 let va_Block (block:va_codes) : Tot va_code = Block block

--- a/tools/Vale/test/fstar1ifc.vaf
+++ b/tools/Vale/test/fstar1ifc.vaf
@@ -28,6 +28,11 @@ type va_code =
   | While : whileCond:ocmp -> whileBody:va_code -> va_code
 and va_codes = list va_code
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let va_CNil () = []
 let va_CCons x y = x::y
 let va_Block (block:va_codes) : Tot va_code = Block block

--- a/tools/Vale/test/nonterm.vaf
+++ b/tools/Vale/test/nonterm.vaf
@@ -30,6 +30,11 @@ type va_code =
   | While : whileCond:ocmp -> whileBody:va_code -> va_code
 and va_codes = list va_code
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let va_CNil () = []
 let va_CCons x y = x::y
 let va_Block (block:va_codes) : Tot va_code = Block block

--- a/tools/Vale/test/overload.vaf
+++ b/tools/Vale/test/overload.vaf
@@ -33,6 +33,11 @@ type va_code =
   | IfElse : ifCond:ocmp -> ifTrue:va_code -> ifFalse:va_code -> va_code
 and va_codes = list va_code
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let va_CNil () = []
 let va_CCons x y = x::y
 let va_Block (block:va_codes) : Tot va_code = Block block

--- a/tools/Vale/test/recursive.vaf
+++ b/tools/Vale/test/recursive.vaf
@@ -26,6 +26,11 @@ type va_code =
   | IfElse : ifCond:ocmp -> ifTrue:va_code -> ifFalse:va_code -> va_code
 and va_codes = list va_code
 
+type va_pbool = Vale.Def.PossiblyMonad.pbool
+let va_ttrue () = Vale.Def.PossiblyMonad.ttrue
+let va_ffalse = Vale.Def.PossiblyMonad.ffalse
+let va_pbool_and x y = Vale.Def.PossiblyMonad.op_Amp_Amp_Dot x y
+
 let va_CNil () = []
 let va_CCons x y = x::y
 let va_Block (block:va_codes) : Tot va_code = Block block


### PR DESCRIPTION
This PR introduces a notion of successful code generation. This is to be used _purely_ for debugging purposes, and has no effect on the `va_code`/`va_lemma`/etc.

In order to introduce the ability to have arbitrary debug output capabilities, we rely upon the `PossiblyMonad`'s `pbool`, which is always either `ttrue` (equivalent to `true`) or is `ffalse reason` (equivalent to `false` but also must provide a string `reason`).

The expected use case for this is for the `.ml` extracted files to look at the relevant `va_codegen_success` and when false, show the message to the user.