### PR TITLE
fix INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,15 +63,15 @@ Note that the mono package includes F\#.
 
 Once these tools are installed, running SCons in the top-level directory will build the Vale tool:
 
-```./build_local.sh```
+```./run_scons.sh```
 
 To verify all Dafny sources in the [src](./src) directory, run:
 
-```python.exe scons.py --DAFNY```
+```./run_scons.sh --DAFNY```
 
 To verify all F* sources in the [src](./src) directory (this requires an installation of [F*](https://github.com/FStarLang/FStar)), run:
 
-```python.exe scons.py --FSTAR```
+```./run_scons.sh --FSTAR```
 
 NOTE: You can override tools/Kremlin by setting the KREMLIN_HOME
 environment variable to point to the directory where KreMLin is

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,7 @@ Note that the mono package includes F\#.
 
 Once these tools are installed, running SCons in the top-level directory will build the Vale tool:
 
-```python.exe scons.py```
+```./build_local.sh```
 
 To verify all Dafny sources in the [src](./src) directory, run:
 

--- a/run_scons.sh
+++ b/run_scons.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-SCONS_PYTHON_MAJOR_MINOR=3.6
+SCONS_PYTHON_MAJOR_MINOR=3.9
 
 # Windows-only: print out the directory of the Python associated to SCons
 windows_scons_python_dir () {


### PR DESCRIPTION
The current INSTALL.md is outdated.

If I run `build_local.sh`, then I will get `Cannot connect to the Docker daemon at unix:///var/run/docker.sock.`